### PR TITLE
Mock S3 client to test ObjectsOnS3

### DIFF
--- a/cantor-common/src/test/java/com/salesforce/cantor/common/AbstractBaseObjectsTest.java
+++ b/cantor-common/src/test/java/com/salesforce/cantor/common/AbstractBaseObjectsTest.java
@@ -32,7 +32,7 @@ public abstract class AbstractBaseObjectsTest extends AbstractBaseCantorTest {
     }
 
     // override to store less (for impls that storing is more expensive) by setting to less than 1
-    private double getStoreMagnitude() {
+    protected double getStoreMagnitude() {
         return 1.0D;
     }
 

--- a/cantor-s3/pom.xml
+++ b/cantor-s3/pom.xml
@@ -27,6 +27,7 @@
     <properties>
         <s3-sdk.version>1.11.538</s3-sdk.version>
         <mockito.version>2.21.0</mockito.version>
+        <jackson.version>2.10.0</jackson.version>
     </properties>
 
     <dependencies>
@@ -34,32 +35,25 @@
             <groupId>com.salesforce.cantor</groupId>
             <artifactId>cantor-common</artifactId>
         </dependency>
-        <!-- S3 SDK -->
+        <!--S3 SDK-->
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk</artifactId>
             <version>${s3-sdk.version}</version>
         </dependency>
 
-        <!-- TEST SCOPE BELOW-->
-        <!-- LOGBACK -->
+        <!--TEST SCOPE BELOW-->
+        <!-- LOGBACK-->
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>
         </dependency>
-        <!--TESTNG -->
+        <!--TESTNG-->
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <version>${testng.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <!--MOCKITO-->
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <!--CANTOR COMMON TEST JAR-->
@@ -68,6 +62,27 @@
             <artifactId>cantor-common</artifactId>
             <type>test-jar</type>
             <version>${project.version}</version>
+        </dependency>
+        <!--S3 MOCK-->
+        <dependency>
+            <groupId>com.adobe.testing</groupId>
+            <artifactId>s3mock-testng</artifactId>
+            <version>2.1.16</version>
+            <scope>test</scope>
+        </dependency>
+        <!--JACKSON CORE-->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!--JACKSON DATABIND-->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/cantor-s3/pom.xml
+++ b/cantor-s3/pom.xml
@@ -28,6 +28,7 @@
         <s3-sdk.version>1.11.538</s3-sdk.version>
         <mockito.version>2.21.0</mockito.version>
         <jackson.version>2.10.0</jackson.version>
+        <s3mock.version>2.1.16</s3mock.version>
     </properties>
 
     <dependencies>
@@ -67,7 +68,7 @@
         <dependency>
             <groupId>com.adobe.testing</groupId>
             <artifactId>s3mock-testng</artifactId>
-            <version>2.1.16</version>
+            <version>${s3mock.version}</version>
             <scope>test</scope>
         </dependency>
         <!--JACKSON CORE-->

--- a/cantor-s3/pom.xml
+++ b/cantor-s3/pom.xml
@@ -26,6 +26,7 @@
 
     <properties>
         <s3-sdk.version>1.11.538</s3-sdk.version>
+        <mockito.version>2.21.0</mockito.version>
     </properties>
 
     <dependencies>
@@ -52,6 +53,13 @@
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <version>${testng.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!--MOCKITO-->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <!--CANTOR COMMON TEST JAR-->

--- a/cantor-s3/src/main/java/com/salesforce/cantor/s3/ObjectsOnS3.java
+++ b/cantor-s3/src/main/java/com/salesforce/cantor/s3/ObjectsOnS3.java
@@ -228,7 +228,6 @@ public class ObjectsOnS3 implements StreamingObjects {
         this.s3Client.deleteBucket(bucket);
 
         // check bucket deleted successfully
-        // todo: remove this check? race condition exists where current thread deletes a bucket and another thread creates a bucket right after, causing this to throw an exception
         if (this.s3Client.doesBucketExistV2(bucket)) {
             throw new IOException("failed to drop namespace on s3 with bucket name: " + bucket);
         }

--- a/cantor-s3/src/main/java/com/salesforce/cantor/s3/ObjectsOnS3.java
+++ b/cantor-s3/src/main/java/com/salesforce/cantor/s3/ObjectsOnS3.java
@@ -19,7 +19,6 @@ import java.io.InputStream;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.regex.Pattern;
 
 import static com.salesforce.cantor.common.CommonPreconditions.checkArgument;
 import static com.salesforce.cantor.common.CommonPreconditions.checkCreate;
@@ -35,7 +34,6 @@ public class ObjectsOnS3 implements StreamingObjects {
     private static final Logger logger = LoggerFactory.getLogger(ObjectsOnS3.class);
 
     private static final String bucketNameFormat = "%s-cantor-namespace-%d";
-    private static final Pattern bucketNamespaceRegex = Pattern.compile("^.+-cantor-namespace-(?<namespace>.*)$");
 
     // read objects in 4MB chunks
     private static final int streamingChunkSize = 4 * 1024 * 1024;

--- a/cantor-s3/src/main/java/com/salesforce/cantor/s3/ObjectsOnS3.java
+++ b/cantor-s3/src/main/java/com/salesforce/cantor/s3/ObjectsOnS3.java
@@ -52,6 +52,7 @@ public class ObjectsOnS3 implements StreamingObjects {
     }
 
     public ObjectsOnS3(final AmazonS3 s3Client, final String bucketPrefix) {
+        // todo: ensure bucket prefix doesn't include periods (or at least doesn't start/end w/ periods)
         checkArgument(s3Client != null, "null s3 client");
         checkString(bucketPrefix, "null/empty bucket prefix");
         this.s3Client = s3Client;
@@ -223,6 +224,7 @@ public class ObjectsOnS3 implements StreamingObjects {
         this.s3Client.deleteBucket(bucket);
 
         // check bucket deleted successfully
+        // todo: remove this check? race condition exists where current thread deletes a bucket and another thread creates a bucket right after, causing this to throw an exception
         if (this.s3Client.doesBucketExistV2(bucket)) {
             throw new IOException("failed to drop namespace on s3 with bucket name: " + bucket);
         }
@@ -233,6 +235,7 @@ public class ObjectsOnS3 implements StreamingObjects {
         final ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentLength(bytes.length);
         logger.info("storing {} object bytes at '{}.{}'", bytes.length, bucket, key);
+        // if no exception is thrown, the object was put successfully - ignore response value
         this.s3Client.putObject(bucket, key, new ByteArrayInputStream(bytes), metadata);
     }
 
@@ -241,6 +244,7 @@ public class ObjectsOnS3 implements StreamingObjects {
         final ObjectMetadata metadata = new ObjectMetadata();
         metadata.setContentLength(length);
         logger.info("storing stream with length={} at '{}.{}'", length, bucket, key);
+        // if no exception is thrown, the object was put successfully - ignore response value
         this.s3Client.putObject(bucket, key, stream, metadata);
     }
 

--- a/cantor-s3/src/main/java/com/salesforce/cantor/s3/ObjectsOnS3.java
+++ b/cantor-s3/src/main/java/com/salesforce/cantor/s3/ObjectsOnS3.java
@@ -2,7 +2,6 @@ package com.salesforce.cantor.s3;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
-import com.amazonaws.services.s3.model.Bucket;
 import com.amazonaws.services.s3.model.ListVersionsRequest;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.ObjectMetadata;
@@ -17,12 +16,9 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static com.salesforce.cantor.common.CommonPreconditions.checkArgument;
@@ -46,17 +42,25 @@ public class ObjectsOnS3 implements StreamingObjects {
 
     private final AmazonS3 s3Client;
     private final String bucketPrefix;
+    private final String bucketNameAllNamespaces;
 
-    public ObjectsOnS3(final AmazonS3 s3Client) {
+    public ObjectsOnS3(final AmazonS3 s3Client) throws IOException {
         this(s3Client, "default");
     }
 
-    public ObjectsOnS3(final AmazonS3 s3Client, final String bucketPrefix) {
+    public ObjectsOnS3(final AmazonS3 s3Client, final String bucketPrefix) throws IOException {
         // todo: ensure bucket prefix doesn't include periods (or at least doesn't start/end w/ periods)
         checkArgument(s3Client != null, "null s3 client");
         checkString(bucketPrefix, "null/empty bucket prefix");
         this.s3Client = s3Client;
         this.bucketPrefix = bucketPrefix;
+        this.bucketNameAllNamespaces = String.format("%s-all-namespaces", bucketPrefix);
+        try {
+            this.s3Client.createBucket(bucketNameAllNamespaces);
+        } catch (final AmazonS3Exception e) {
+            logger.warn("exception creating required buckets for objects on s3:", e);
+            throw new IOException("exception creating required buckets for objects on s3:", e);
+        }
     }
 
     @Override
@@ -177,13 +181,15 @@ public class ObjectsOnS3 implements StreamingObjects {
             logger.info("bucket '{}' already exists; ignoring create", bucket);
             return;
         }
-        logger.info("bucket '{}' doesn't exist; creating it", bucket);
+        logger.info("bucket '{}' for namespace '{}' doesn't exist; creating it", bucket, namespace);
         this.s3Client.createBucket(bucket);
 
         // check bucket created successfully
         if (!this.s3Client.doesBucketExistV2(bucket)) {
             throw new IOException("failed to create namespace on s3 with bucket name: " + bucket);
         }
+        // keep a record of the namespace in the namespaces bucket
+        this.s3Client.putObject(bucketNameAllNamespaces, namespace, bucket);
     }
 
     private void doDrop(final String namespace) throws IOException {
@@ -228,6 +234,9 @@ public class ObjectsOnS3 implements StreamingObjects {
         if (this.s3Client.doesBucketExistV2(bucket)) {
             throw new IOException("failed to drop namespace on s3 with bucket name: " + bucket);
         }
+
+        // delete the record in the namespaces bucket
+        deleteObject(bucketNameAllNamespaces, namespace);
     }
 
     private void doStore(final String namespace, final String key, final byte[] bytes) {
@@ -295,17 +304,7 @@ public class ObjectsOnS3 implements StreamingObjects {
         if (!this.s3Client.doesObjectExist(bucket, key)) {
             return false;
         }
-        try {
-            this.s3Client.deleteObject(toBucketName(namespace), key);
-            final VersionListing versionList = this.s3Client.listVersions(bucket, key);
-            for (final S3VersionSummary summary : versionList.getVersionSummaries()) {
-                logger.debug("deleting version {}", summary.getKey());
-                this.s3Client.deleteVersion(bucket, summary.getKey(), summary.getVersionId());
-            }
-            return true;
-        } catch (final AmazonS3Exception exception) {
-            throw new IOException(exception);
-        }
+        return deleteObject(bucket, key);
     }
 
     private int doSize(final String namespace) {
@@ -325,13 +324,15 @@ public class ObjectsOnS3 implements StreamingObjects {
         return totalSize;
     }
 
-
     private Collection<String> doKeys(final String namespace, final int start, final int count) throws IOException {
         final String bucket = toBucketName(namespace);
         if (!this.s3Client.doesBucketExistV2(bucket)) {
             throw new IOException(String.format("couldn't find bucket '%s' for namespace '%s'", bucket, namespace));
         }
+        return getKeys(bucket, start, count);
+    }
 
+    private Collection<String> getKeys(final String bucket, final int start, final int count) {
         final Set<String> keys = new HashSet<>();
         int index = 0;
         ObjectListing listing = this.s3Client.listObjects(bucket);
@@ -356,19 +357,19 @@ public class ObjectsOnS3 implements StreamingObjects {
         return keys;
     }
 
-    private Collection<String> doGetNamespaces() {
-        final List<Bucket> buckets = this.s3Client.listBuckets();
-        final List<String> namespaces = new ArrayList<>(buckets.size());
-
-        for (final Bucket bucket : buckets) {
-            final Matcher matcher = bucketNamespaceRegex.matcher(bucket.getName());
-            if (!matcher.matches() || matcher.group("namespace") == null) {
-                continue;
-            }
-            namespaces.add(matcher.group("namespace"));
+    private boolean deleteObject(final String bucket, final String key) {
+        this.s3Client.deleteObject(bucket, key);
+        final VersionListing versionList = this.s3Client.listVersions(bucket, key);
+        for (final S3VersionSummary summary : versionList.getVersionSummaries()) {
+            logger.debug("deleting version {}", summary.getKey());
+            this.s3Client.deleteVersion(bucket, summary.getKey(), summary.getVersionId());
         }
 
-        return namespaces;
+        return true;
+    }
+
+    private Collection<String> doGetNamespaces() {
+        return getKeys(bucketNameAllNamespaces, 0, -1);
     }
 
     private String toBucketName(final String namespace) {

--- a/cantor-s3/src/test/java/com/salesforce/cantor/s3/ObjectsOnS3Test.java
+++ b/cantor-s3/src/test/java/com/salesforce/cantor/s3/ObjectsOnS3Test.java
@@ -2,6 +2,7 @@ package com.salesforce.cantor.s3;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.Bucket;
+import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import org.mockito.stubbing.Answer;
 
@@ -9,13 +10,14 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
 
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class ObjectsOnS3Test {
-
 
     private AmazonS3 mockS3Client() {
         final Map<String, MockedBucket> bucketMock = new HashMap<>();
@@ -29,9 +31,38 @@ public class ObjectsOnS3Test {
 
         // "create" the bucket by adding an empty list to the map of mocked buckets
         when(s3Mock.createBucket(anyString())).then(mockArg -> bucketMock.put(mockArg.getArgument(0).toString(), new MockedBucket(mockArg.getArgument(0).toString())));
+        // list objects from the map of mocked buckets
+        when(s3Mock.listObjects(anyString())).then(mockArg -> getObjectListing(bucketMock, mockArg.getArgument(0).toString()));
+        //  delete objects
+        doAnswer(invocation -> {
+
+        }).when(s3Mock.deleteObject(anyString(), anyString()));
     }
 
-    private class MockedBucket {
+    private ObjectListing getObjectListing(final Map<String, MockedBucket> bucketMock, final String bucketName) {
+        final MockedBucket bucket = bucketMock.get(bucketName);
+        if (bucket == null) {
+            return null;
+        }
+        return new ObjectListing() {
+            final int increments = Math.max(1, ThreadLocalRandom.current().nextInt(1, bucket.objects.size() / 5));
+            int i = 0;
+
+            @Override
+            public boolean isTruncated() {
+                return i < bucket.objects.size();
+            }
+
+            @Override
+            public List<S3ObjectSummary> getObjectSummaries() {
+                final int start = i;
+                i = Math.min(bucket.objects.size(), i + increments);
+                return new ArrayList<>(bucket.objects.subList(start, i));
+            }
+        };
+    }
+
+    private static class MockedBucket {
         final Bucket bucket;
         final List<S3ObjectSummary> objects;
 

--- a/cantor-s3/src/test/java/com/salesforce/cantor/s3/ObjectsOnS3Test.java
+++ b/cantor-s3/src/test/java/com/salesforce/cantor/s3/ObjectsOnS3Test.java
@@ -1,0 +1,43 @@
+package com.salesforce.cantor.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.Bucket;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import org.mockito.stubbing.Answer;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ObjectsOnS3Test {
+
+
+    private AmazonS3 mockS3Client() {
+        final Map<String, MockedBucket> bucketMock = new HashMap<>();
+        final AmazonS3 s3Mock = mock(AmazonS3.class);
+
+        // a bucket exists if it's been added to the map of mocked buckets
+        when(s3Mock.doesBucketExistV2(anyString())).then((Answer<Boolean>) mockArg -> {
+            final String bucketKey = mockArg.getArgument(0).toString();
+            return bucketMock.containsKey(bucketKey);
+        });
+
+        // "create" the bucket by adding an empty list to the map of mocked buckets
+        when(s3Mock.createBucket(anyString())).then(mockArg -> bucketMock.put(mockArg.getArgument(0).toString(), new MockedBucket(mockArg.getArgument(0).toString())));
+    }
+
+    private class MockedBucket {
+        final Bucket bucket;
+        final List<S3ObjectSummary> objects;
+
+        private MockedBucket(final String name) {
+            this.bucket = new Bucket(name);
+            this.objects = new ArrayList<>();
+        }
+    }
+}

--- a/cantor-s3/src/test/java/com/salesforce/cantor/s3/ObjectsOnS3Test.java
+++ b/cantor-s3/src/test/java/com/salesforce/cantor/s3/ObjectsOnS3Test.java
@@ -1,74 +1,25 @@
 package com.salesforce.cantor.s3;
 
+import com.adobe.testing.s3mock.testng.S3Mock;
+import com.adobe.testing.s3mock.testng.S3MockListener;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.Bucket;
-import com.amazonaws.services.s3.model.ObjectListing;
-import com.amazonaws.services.s3.model.S3ObjectSummary;
-import org.mockito.stubbing.Answer;
+import com.salesforce.cantor.Cantor;
+import com.salesforce.cantor.common.AbstractBaseObjectsTest;
+import org.testng.annotations.Listeners;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ThreadLocalRandom;
+import java.io.IOException;
 
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+@Listeners(value = { S3MockListener.class })
+public class ObjectsOnS3Test extends AbstractBaseObjectsTest {
 
-public class ObjectsOnS3Test {
-
-    private AmazonS3 mockS3Client() {
-        final Map<String, MockedBucket> bucketMock = new HashMap<>();
-        final AmazonS3 s3Mock = mock(AmazonS3.class);
-
-        // a bucket exists if it's been added to the map of mocked buckets
-        when(s3Mock.doesBucketExistV2(anyString())).then((Answer<Boolean>) mockArg -> {
-            final String bucketKey = mockArg.getArgument(0).toString();
-            return bucketMock.containsKey(bucketKey);
-        });
-
-        // "create" the bucket by adding an empty list to the map of mocked buckets
-        when(s3Mock.createBucket(anyString())).then(mockArg -> bucketMock.put(mockArg.getArgument(0).toString(), new MockedBucket(mockArg.getArgument(0).toString())));
-        // list objects from the map of mocked buckets
-        when(s3Mock.listObjects(anyString())).then(mockArg -> getObjectListing(bucketMock, mockArg.getArgument(0).toString()));
-        //  delete objects
-        doAnswer(invocation -> {
-
-        }).when(s3Mock.deleteObject(anyString(), anyString()));
+    @Override
+    protected double getStoreMagnitude() {
+        return 0.25;
     }
 
-    private ObjectListing getObjectListing(final Map<String, MockedBucket> bucketMock, final String bucketName) {
-        final MockedBucket bucket = bucketMock.get(bucketName);
-        if (bucket == null) {
-            return null;
-        }
-        return new ObjectListing() {
-            final int increments = Math.max(1, ThreadLocalRandom.current().nextInt(1, bucket.objects.size() / 5));
-            int i = 0;
-
-            @Override
-            public boolean isTruncated() {
-                return i < bucket.objects.size();
-            }
-
-            @Override
-            public List<S3ObjectSummary> getObjectSummaries() {
-                final int start = i;
-                i = Math.min(bucket.objects.size(), i + increments);
-                return new ArrayList<>(bucket.objects.subList(start, i));
-            }
-        };
-    }
-
-    private static class MockedBucket {
-        final Bucket bucket;
-        final List<S3ObjectSummary> objects;
-
-        private MockedBucket(final String name) {
-            this.bucket = new Bucket(name);
-            this.objects = new ArrayList<>();
-        }
+    @Override
+    protected Cantor getCantor() throws IOException {
+        final AmazonS3 s3Client = S3Mock.getInstance().createS3Client("us-west-1");
+        return new CantorOnS3(s3Client);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <slf4j.version>1.7.25</slf4j.version>
         <logback.version>1.2.3</logback.version>
 
-        <testng.version>6.13.1</testng.version>
+        <testng.version>7.0.0</testng.version>
 
         <mvn.plugins.compiler.version>2.5.1</mvn.plugins.compiler.version>
         <mvn.plugins.javadoc.version>2.10.1</mvn.plugins.javadoc.version>


### PR DESCRIPTION
This uses the adobe S3Mock library, rather than mocking all of the s3 functionality manually.

This also fixes an issue found with the ObjectsOnS3 `namespaces()` implementation. Bucket names are created by hashing the given namespace, to avoid namespaces breaking s3 bucket naming requirements. As such, we have to keep a bucket containing all namespaces.  