### PR TITLE
Replace uses of INTERSECT in MySQL cantor

### DIFF
--- a/cantor-jdbc/src/main/java/com/salesforce/cantor/jdbc/AbstractBaseEventsOnJdbc.java
+++ b/cantor-jdbc/src/main/java/com/salesforce/cantor/jdbc/AbstractBaseEventsOnJdbc.java
@@ -866,7 +866,7 @@ public abstract class AbstractBaseEventsOnJdbc extends AbstractBaseCantorOnJdbc 
         try (final Connection connection = getConnection()) {
             try (final PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
                 addParameters(preparedStatement, parameters);
-                logger.info("executing sql query [[{}]] with parameters (({}))", sql, parameters);
+                logger.debug("executing sql query [[{}]] with parameters (({}))", sql, parameters);
                 try (final ResultSet resultSet = preparedStatement.executeQuery()) {
                     while (resultSet.next()) {
                         tables.add(resultSet.getString(1));

--- a/cantor-jdbc/src/main/java/com/salesforce/cantor/jdbc/AbstractBaseEventsOnJdbc.java
+++ b/cantor-jdbc/src/main/java/com/salesforce/cantor/jdbc/AbstractBaseEventsOnJdbc.java
@@ -829,8 +829,9 @@ public abstract class AbstractBaseEventsOnJdbc extends AbstractBaseCantorOnJdbc 
         final Object[] parameters = new Object[2 + metadataKeys.size() + dimensionKeys.size()];
         sqlFormatBuilder.append("SELECT DISTINCT ").append(quote(getTableNameColumnName()))
                 .append(" FROM ").append(getTableFullName(namespace, getChunksLookupTableName()))
-                .append(" WHERE ")
-                .append(quote(getStartTimestampMillisColumnName())).append(" BETWEEN ? AND ? ")
+                .append(" WHERE (")
+                .append(quote(getStartTimestampMillisColumnName()))
+                .append(" BETWEEN ? AND ?)")
         ;
         int index = 0;
         final long startWindow = getWindowForTimestamp(startTimestampMillis) - getWindowSizeMillis();
@@ -840,25 +841,32 @@ public abstract class AbstractBaseEventsOnJdbc extends AbstractBaseCantorOnJdbc 
                 ? getWindowForTimestamp(endTimestampMillis) + getWindowSizeMillis()
                 : Long.MAX_VALUE;
         parameters[index++] = endTimestampWindow;
+
+        // metadata table names are OR'd together, find table names that have matching column names
+        final StringBuilder clauseBuilder = new StringBuilder();
+        final StringJoiner tableNameWhere = new StringJoiner(" OR ", "(", ")");
         for (final String metadataKey : metadataKeys) {
-            sqlFormatBuilder.append(" INTERSECT SELECT DISTINCT ").append(quote(getTableNameColumnName()))
-                    .append(" FROM ").append(getTableFullName(namespace, getChunksLookupTableName()))
-                    .append(" WHERE ")
-                    .append(quote(getColumnColumnName())).append(" = ? ");
+            clauseBuilder.setLength(0);
+            clauseBuilder.append("(").append(quote(getColumnColumnName())).append(" = ?)");
+            tableNameWhere.add(clauseBuilder.toString());
             parameters[index++] = getMetadataKeyColumnName(metadataKey);
         }
         for (final String dimensionKey : dimensionKeys) {
-            sqlFormatBuilder.append(" INTERSECT SELECT DISTINCT ").append(quote(getTableNameColumnName()))
-                    .append(" FROM ").append(getTableFullName(namespace, getChunksLookupTableName()))
-                    .append(" WHERE ")
-                    .append(quote(getColumnColumnName())).append(" = ? ");
+            clauseBuilder.setLength(0);
+            clauseBuilder.append("(").append(quote(getColumnColumnName())).append(" = ?)");
+            tableNameWhere.add(clauseBuilder.toString());
             parameters[index++] = getDimensionKeyColumnName(dimensionKey);
         }
+        if (!metadataKeys.isEmpty() || !dimensionKeys.isEmpty()) {
+            sqlFormatBuilder.append(" AND (").append(tableNameWhere.toString()).append(")");
+        }
+
         final List<String> tables = new ArrayList<>();
         final String sql = sqlFormatBuilder.toString();
         try (final Connection connection = getConnection()) {
             try (final PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
                 addParameters(preparedStatement, parameters);
+                logger.info("executing sql query [[{}]] with parameters (({}))", sql, parameters);
                 try (final ResultSet resultSet = preparedStatement.executeQuery()) {
                     while (resultSet.next()) {
                         tables.add(resultSet.getString(1));

--- a/cantor-jdbc/src/main/java/com/salesforce/cantor/jdbc/AbstractBaseMapsOnJdbc.java
+++ b/cantor-jdbc/src/main/java/com/salesforce/cantor/jdbc/AbstractBaseMapsOnJdbc.java
@@ -13,17 +13,27 @@ import org.slf4j.LoggerFactory;
 
 import javax.sql.DataSource;
 import java.io.IOException;
-import java.sql.*;
-import java.util.*;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import static com.salesforce.cantor.common.CommonPreconditions.checkCreate;
 import static com.salesforce.cantor.common.CommonPreconditions.checkDrop;
-import static com.salesforce.cantor.common.MapsPreconditions.*;
+import static com.salesforce.cantor.common.MapsPreconditions.checkDelete;
+import static com.salesforce.cantor.common.MapsPreconditions.checkGet;
+import static com.salesforce.cantor.common.MapsPreconditions.checkStore;
 import static com.salesforce.cantor.jdbc.JdbcUtils.addParameters;
 import static com.salesforce.cantor.jdbc.JdbcUtils.quote;
 
@@ -340,6 +350,7 @@ public abstract class AbstractBaseMapsOnJdbc extends AbstractBaseCantorOnJdbc im
         final String sql = sqlFormatBuilder.toString();
         try (final Connection connection = getConnection()) {
             try (final PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
+                logger.info("executing sql query [[{}]] with parameters (({}))", sql, parameters);
                 addParameters(preparedStatement, parameters);
                 try (final ResultSet resultSet = preparedStatement.executeQuery()) {
                     while (resultSet.next()) {

--- a/cantor-jdbc/src/main/java/com/salesforce/cantor/jdbc/AbstractBaseSetsOnJdbc.java
+++ b/cantor-jdbc/src/main/java/com/salesforce/cantor/jdbc/AbstractBaseSetsOnJdbc.java
@@ -17,6 +17,7 @@ import java.sql.*;
 import java.util.*;
 
 import static com.salesforce.cantor.common.SetsPreconditions.*;
+import static com.salesforce.cantor.jdbc.JdbcUtils.addParameters;
 import static com.salesforce.cantor.jdbc.JdbcUtils.getPlaceholders;
 import static com.salesforce.cantor.jdbc.JdbcUtils.quote;
 
@@ -284,15 +285,22 @@ public abstract class AbstractBaseSetsOnJdbc extends AbstractBaseCantorOnJdbc im
                                           final int start,
                                           final int count,
                                           final String orderby) throws IOException {
-        final String partialSql = String.format("SELECT %s, %s FROM %s WHERE %s = ? AND %s BETWEEN ? AND ?",
+        final StringJoiner setsJoiner = new StringJoiner(" OR ");
+        final String clause = getSetKeyColumnName() + " = ?";
+        int index = 0;
+        final Object[] parameters = new Object[sets.size() + 2];
+        parameters[index++] = min;
+        parameters[index++] = max;
+        for (final String set : sets) {
+            parameters[index++] = set;
+            setsJoiner.add(clause);
+        }
+        final String sql = String.format("SELECT %s, %s FROM %s WHERE %s BETWEEN ? AND ? AND %s %s %s",
                 quote(getEntryColumnName()),
                 quote(getWeightColumnName()),
                 getTableFullName(namespace, getSetsTableName()),
-                quote(getSetKeyColumnName()),
-                quote(getWeightColumnName())
-        );
-        final String sql = String.format("%s %s %s",
-                String.join(" INTERSECT ", Collections.nCopies(sets.size(), partialSql)),
+                quote(getWeightColumnName()),
+                setsJoiner.toString(),
                 orderby,
                 getLimitString(start, count)
         );
@@ -300,12 +308,7 @@ public abstract class AbstractBaseSetsOnJdbc extends AbstractBaseCantorOnJdbc im
         try (final Connection connection = getConnection()) {
             logger.debug("executing sql query: {}", sql);
             try (final PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
-                int index = 1;
-                for (final String set : sets) {
-                    preparedStatement.setString(index++, set);
-                    preparedStatement.setLong(index++, min);
-                    preparedStatement.setLong(index++, max);
-                }
+                addParameters(preparedStatement, parameters);
                 try (final ResultSet resultSet = preparedStatement.executeQuery()) {
                     while (resultSet.next()) {
                         final String key = resultSet.getString(1);

--- a/cantor-jdbc/src/main/java/com/salesforce/cantor/jdbc/AbstractBaseSetsOnJdbc.java
+++ b/cantor-jdbc/src/main/java/com/salesforce/cantor/jdbc/AbstractBaseSetsOnJdbc.java
@@ -298,6 +298,7 @@ public abstract class AbstractBaseSetsOnJdbc extends AbstractBaseCantorOnJdbc im
         );
         final Map<String, Long> items = new LinkedHashMap<>();
         try (final Connection connection = getConnection()) {
+            logger.debug("executing sql query: {}", sql);
             try (final PreparedStatement preparedStatement = connection.prepareStatement(sql)) {
                 int index = 1;
                 for (final String set : sets) {

--- a/cantor-jdbc/src/main/java/com/salesforce/cantor/jdbc/AbstractBaseSetsOnJdbc.java
+++ b/cantor-jdbc/src/main/java/com/salesforce/cantor/jdbc/AbstractBaseSetsOnJdbc.java
@@ -285,12 +285,13 @@ public abstract class AbstractBaseSetsOnJdbc extends AbstractBaseCantorOnJdbc im
                                           final int start,
                                           final int count,
                                           final String orderby) throws IOException {
-        final StringJoiner setsJoiner = new StringJoiner(" OR ");
-        final String clause = getSetKeyColumnName() + " = ?";
         int index = 0;
         final Object[] parameters = new Object[sets.size() + 2];
         parameters[index++] = min;
         parameters[index++] = max;
+        // set keys are OR'd together to get all matching set entries
+        final StringJoiner setsJoiner = new StringJoiner(" OR ");
+        final String clause = getSetKeyColumnName() + " = ?";
         for (final String set : sets) {
             parameters[index++] = set;
             setsJoiner.add(clause);


### PR DESCRIPTION
Resolves #8 

I didn't need to use joins, as the queries are all across only a single table. Most likely some refactoring from awhile back left these `INTERSECT` uses in. 

All uses of `INTERSECT` were replaced with added checks in the `WHERE` clause that are `OR`'d together. 