### PR TITLE
Add utility module for archiving namespaces

### DIFF
--- a/cantor-archive/pom.xml
+++ b/cantor-archive/pom.xml
@@ -54,12 +54,16 @@
             <artifactId>commons-compress</artifactId>
             <version>${apache.commons-compress.version}</version>
         </dependency>
+
+        <!-- TEST DEPENDENCIES -->
+        <!--TESTNG-->
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <version>${testng.version}</version>
             <scope>test</scope>
         </dependency>
+        <!--CANTOR H2-->
         <dependency>
             <groupId>com.salesforce.cantor</groupId>
             <artifactId>cantor-h2</artifactId>
@@ -76,6 +80,7 @@
 
     <build>
         <extensions>
+            <!--OS EXTENSION-->
             <extension>
                 <groupId>kr.motd.maven</groupId>
                 <artifactId>os-maven-plugin</artifactId>
@@ -83,6 +88,7 @@
             </extension>
         </extensions>
         <plugins>
+            <!--PROTOBUF COMPILER-->
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>

--- a/cantor-archive/pom.xml
+++ b/cantor-archive/pom.xml
@@ -19,7 +19,8 @@
     <parent>
         <artifactId>cantor-parent</artifactId>
         <groupId>com.salesforce.cantor</groupId>
-        <version>0.0.4-SNAPSHOT</version>
+        <version>0.0.5-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <properties>

--- a/cantor-archive/pom.xml
+++ b/cantor-archive/pom.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright (c) 2019, Salesforce.com, Inc.
+  ~ All rights reserved.
+  ~ SPDX-License-Identifier: BSD-3-Clause
+  ~ For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>cantor-archive</artifactId>
+    <packaging>jar</packaging>
+    <name>cantor-archive</name>
+    <description>Cantor Archive Utilities</description>
+
+    <parent>
+        <artifactId>cantor-parent</artifactId>
+        <groupId>com.salesforce.cantor</groupId>
+        <version>0.0.4-SNAPSHOT</version>
+    </parent>
+
+    <properties>
+        <maven.plugin.os.version>1.6.0</maven.plugin.os.version>
+        <maven.plugin.protobuf.version>0.6.1</maven.plugin.protobuf.version>
+        <protobuf.version>3.4.0</protobuf.version>
+        <apache.commons-compress.version>1.19</apache.commons-compress.version>
+    </properties>
+
+    <dependencies>
+        <!--CANTOR BASE-->
+        <dependency>
+            <groupId>com.salesforce.cantor</groupId>
+            <artifactId>cantor-base</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!--CANTOR COMMON-->
+        <dependency>
+            <groupId>com.salesforce.cantor</groupId>
+            <artifactId>cantor-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!--PROTOBUF-->
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>${protobuf.version}</version>
+        </dependency>
+        <!--APACHE COMMONS COMPRESS-->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>${apache.commons-compress.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>${testng.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.salesforce.cantor</groupId>
+            <artifactId>cantor-h2</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- LOGBACK-->
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>${maven.plugin.os.version}</version>
+            </extension>
+        </extensions>
+        <plugins>
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>${maven.plugin.protobuf.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/cantor-archive/src/main/java/com/salesforce/cantor/archive/CantorArchiver.java
+++ b/cantor-archive/src/main/java/com/salesforce/cantor/archive/CantorArchiver.java
@@ -1,0 +1,97 @@
+package com.salesforce.cantor.archive;
+
+import com.google.protobuf.ByteString;
+import com.salesforce.cantor.Objects;
+import org.apache.commons.compress.archivers.ArchiveEntry;
+import org.apache.commons.compress.archivers.ArchiveInputStream;
+import org.apache.commons.compress.archivers.ArchiveOutputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static com.salesforce.cantor.common.CommonPreconditions.checkArgument;
+import static com.salesforce.cantor.common.CommonPreconditions.checkString;
+
+public class CantorArchiver {
+    private static final Logger logger = LoggerFactory.getLogger(CantorArchiver.class);
+
+    private static final int maxObjectChunkSize = 1_000;
+
+    public static void archive(final Objects objects, final String namespace, final Path destination) throws IOException {
+        checkArgument(objects != null, "null objects, can't archive");
+        checkString(namespace, "null/empty namespace, can't archive");
+        checkArgument(Files.notExists(destination), "destination already exists, can't archive");
+
+        final int size = objects.size(namespace);
+        // todo: handle empty namespace (size == 0)
+        int start = 0;
+        try (final ArchiveOutputStream archive = getArchiveOutputStream(destination)) {
+            // todo: add metadata tar entry?
+            do {
+                final Map<String, byte[]> chunk = objects.get(namespace, objects.keys(namespace, start, maxObjectChunkSize));
+                final int end = start + chunk.size();
+                final String name = String.format("objects-%s-%s-%s", namespace, start, end);
+                writeArchiveEntry(archive, name, getBytes(chunk));
+                logger.info("archived {} objects ({}-{} out of {}) into chunk '{}'", chunk.size(), start, end, size, name);
+                start = end;
+            } while (start != size);
+        }
+    }
+
+    public static void restore(final Objects objects, final String namespace, final Path archiveFile) throws IOException {
+        checkArgument(objects != null, "null objects, can't restore");
+        checkString(namespace, "null/empty namespace, can't restore");
+        checkArgument(Files.exists(archiveFile), "can't locate archive file, can't restore");
+
+        // todo: should we do this? or require the user create this themselves?
+        objects.create(namespace);
+        try (final ArchiveInputStream archive = getArchiveInputStream(archiveFile)) {
+            ArchiveEntry entry;
+            while ((entry = archive.getNextEntry()) != null) {
+                final ObjectsChunk chunk = ObjectsChunk.parseFrom(archive);
+                // todo: store these all at once? converting will double memory we hold onto, but will store quicker
+                for (final Map.Entry<String, ByteString> chunkEntry : chunk.getObjectsMap().entrySet()) {
+                    objects.store(namespace, chunkEntry.getKey(), chunkEntry.getValue().toByteArray());
+                }
+                logger.info("read {} objects from chunk {} ({} bytes) into {}", chunk.getObjectsCount(), entry.getName(), entry.getSize(), objects);
+            }
+        }
+    }
+
+    private static void writeArchiveEntry(final ArchiveOutputStream archive, final String name, final byte[] bytes) throws IOException {
+        final TarArchiveEntry entry = new TarArchiveEntry(name);
+        entry.setSize(bytes.length);
+        archive.putArchiveEntry(entry);
+        archive.write(bytes);
+        archive.closeArchiveEntry();
+    }
+
+    private static byte[] getBytes(final Map<String, byte[]> chunk) {
+        final ObjectsChunk.Builder builder = ObjectsChunk.newBuilder();
+        // have to convert all byte arrays into proto byte strings
+        for (final Map.Entry<String, byte[]> entry : chunk.entrySet()) {
+            builder.putObjects(entry.getKey(), ByteString.copyFrom(entry.getValue()));
+        }
+        return builder.build().toByteArray();
+    }
+
+    private static ArchiveOutputStream getArchiveOutputStream(final Path destination) throws IOException {
+        return new TarArchiveOutputStream(new GzipCompressorOutputStream(new BufferedOutputStream(Files.newOutputStream(destination))));
+    }
+
+    private static ArchiveInputStream getArchiveInputStream(final Path archiveFile) throws IOException {
+        return new TarArchiveInputStream(new GzipCompressorInputStream(new BufferedInputStream(Files.newInputStream(archiveFile))));
+    }
+
+}

--- a/cantor-archive/src/main/java/com/salesforce/cantor/archive/CantorArchiver.java
+++ b/cantor-archive/src/main/java/com/salesforce/cantor/archive/CantorArchiver.java
@@ -35,8 +35,6 @@ public class CantorArchiver {
 
         final int size = objects.size(namespace);
         try (final ArchiveOutputStream archive = getArchiveOutputStream(destination)) {
-            // todo: add metadata tar entry?
-
             // get objects to archive in chunks in case of large namespaces
             int start = 0;
             while (start != size) {
@@ -56,14 +54,13 @@ public class CantorArchiver {
         checkString(namespace, "null/empty namespace, can't restore");
         checkArgument(Files.exists(archiveFile), "can't locate archive file, can't restore");
 
-        // todo: should we create this namespace? or require the user create this themselves?
+        // create the namespace, in case the user hasn't already
         objects.create(namespace);
         try (final ArchiveInputStream archive = getArchiveInputStream(archiveFile)) {
             ArchiveEntry entry;
             int total = 0;
             while ((entry = archive.getNextEntry()) != null) {
                 final ObjectsChunk chunk = ObjectsChunk.parseFrom(archive);
-                // todo: store these all at once? converting will double memory we hold onto, but will store quicker
                 for (final Map.Entry<String, ByteString> chunkEntry : chunk.getObjectsMap().entrySet()) {
                     objects.store(namespace, chunkEntry.getKey(), chunkEntry.getValue().toByteArray());
                 }

--- a/cantor-archive/src/main/proto/archive.proto
+++ b/cantor-archive/src/main/proto/archive.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "com.salesforce.cantor.archive";
+option java_outer_classname = "Archive";
+option objc_class_prefix = "ArchiveProtos";
+// todo: set compiler options to minimize byte[] representation
+
+import "google/protobuf/any.proto";
+
+//message Archive {
+//    string hash = 1;
+//    map<string, string> metadata = 2;
+//    map<string, double> dimensions = 3;
+//    repeated google.protobuf.Any items = 4;
+//}
+
+message ObjectsChunk {
+    map<string, bytes> objects = 1;
+}
+

--- a/cantor-archive/src/main/proto/archive.proto
+++ b/cantor-archive/src/main/proto/archive.proto
@@ -4,16 +4,8 @@ option java_multiple_files = true;
 option java_package = "com.salesforce.cantor.archive";
 option java_outer_classname = "Archive";
 option objc_class_prefix = "ArchiveProtos";
-// todo: set compiler options to minimize byte[] representation
 
 import "google/protobuf/any.proto";
-
-//message Archive {
-//    string hash = 1;
-//    map<string, string> metadata = 2;
-//    map<string, double> dimensions = 3;
-//    repeated google.protobuf.Any items = 4;
-//}
 
 message ObjectsChunk {
     map<string, bytes> objects = 1;

--- a/cantor-archive/src/test/java/com/salesforce/cantor/archive/CantorArchiverTest.java
+++ b/cantor-archive/src/test/java/com/salesforce/cantor/archive/CantorArchiverTest.java
@@ -1,0 +1,67 @@
+package com.salesforce.cantor.archive;
+
+import com.salesforce.cantor.Cantor;
+import com.salesforce.cantor.Objects;
+import com.salesforce.cantor.h2.CantorOnH2;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+public class CantorArchiverTest {
+
+    @Test
+    public void testArchiveRestoreObjects() throws IOException {
+        final String basePath = "/tmp/cantor-archive-objects-test/" + UUID.randomUUID().toString();
+        final Cantor cantor = getCantor(basePath  + "/input/");
+        final String namespace = UUID.randomUUID().toString();
+        final Map<String, byte[]> stored = populateObjects(cantor.objects(), namespace, ThreadLocalRandom.current().nextInt(1_000, 5_000));
+        assertEquals(cantor.objects().size(namespace), stored.size(), "didn't store expected values");
+
+        Files.createDirectories(Paths.get(basePath, "output"));
+        final Path outputPath = Paths.get(basePath, "output", namespace + ".tar.gz");
+        CantorArchiver.archive(cantor.objects(), namespace, outputPath);
+
+        assertTrue(Files.exists(outputPath), "archive file missing");
+        assertNotEquals(Files.size(outputPath), 0, "empty archive file shouldn't exist");
+
+        final String vNamespace = UUID.randomUUID().toString();
+        final Cantor vCantor = getCantor(basePath + "/verify/");
+        assertThrows(IOException.class, () -> vCantor.objects().size(vNamespace));
+        CantorArchiver.restore(vCantor.objects(), vNamespace, outputPath);
+
+        assertEquals(vCantor.objects().size(vNamespace), stored.size(), "didn't restore expected number of objects");
+        final Collection<String> vKeys = vCantor.objects().keys(vNamespace, 0, -1);
+        for (final String key : vKeys) {
+            assertEquals(vCantor.objects().get(vNamespace, key), stored.get(key), "restored object doesn't match stored");
+        }
+    }
+
+    private static Map<String, byte[]> populateObjects(final Objects objects, final String namespace, final int count) throws IOException {
+        objects.create(namespace);
+        final Map<String, byte[]> stored = new HashMap<>();
+        for (int i = 0; i < count; i++) {
+            final String key = UUID.randomUUID().toString();
+            stored.put(key, key.getBytes());
+            objects.store(namespace, key, key.getBytes());
+        }
+        return stored;
+    }
+
+    private static Cantor getCantor(final String path) throws IOException {
+        return new CantorOnH2(path);
+    }
+
+}

--- a/cantor-archive/src/test/java/com/salesforce/cantor/archive/CantorArchiverTest.java
+++ b/cantor-archive/src/test/java/com/salesforce/cantor/archive/CantorArchiverTest.java
@@ -31,7 +31,7 @@ public class CantorArchiverTest {
         assertEquals(cantor.objects().size(namespace), stored.size(), "didn't store expected values");
 
         Files.createDirectories(Paths.get(basePath, "output"));
-        final Path outputPath = Paths.get(basePath, "output", namespace + ".tar.gz");
+        final Path outputPath = Paths.get(basePath, "output",  "test-archive.tar.gz");
         CantorArchiver.archive(cantor.objects(), namespace, outputPath);
 
         assertTrue(Files.exists(outputPath), "archive file missing");
@@ -47,6 +47,22 @@ public class CantorArchiverTest {
         for (final String key : vKeys) {
             assertEquals(vCantor.objects().get(vNamespace, key), stored.get(key), "restored object doesn't match stored");
         }
+    }
+
+    @Test
+    public void testArchiveZeroObjectsNamespace() throws IOException {
+        final String basePath = "/tmp/cantor-archive-objects-test-zero/" + UUID.randomUUID().toString();
+        final Cantor cantor = getCantor(basePath  + "/input/");
+        final String namespace = UUID.randomUUID().toString();
+        cantor.objects().create(namespace);
+
+        Files.createDirectories(Paths.get(basePath, "output"));
+        final Path outputPath = Paths.get(basePath, "output", "test-archive.tar.gz");
+        CantorArchiver.archive(cantor.objects(), namespace, outputPath);
+        assertTrue(Files.exists(outputPath), "archiving zero objects should still produce file");
+
+        CantorArchiver.restore(cantor.objects(), namespace, outputPath);
+        assertEquals(cantor.objects().size(namespace), 0,  "shouldn't have restored any objects");
     }
 
     private static Map<String, byte[]> populateObjects(final Objects objects, final String namespace, final int count) throws IOException {

--- a/cantor-archive/src/test/resources/logback-test.xml
+++ b/cantor-archive/src/test/resources/logback-test.xml
@@ -1,0 +1,19 @@
+<!--
+  ~ Copyright (c) 2018, salesforce.com, inc.
+  ~ All rights reserved.
+  ~ SPDX-License-Identifier: BSD-3-Clause
+  ~ For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+  -->
+
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date{YYYY-MM-dd HH:mm:ss} %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>
+

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,7 @@
         <module>cantor-misc</module>
         <module>cantor-server</module>
         <module>cantor-http-server</module>
+        <module>cantor-archive</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
Provides the `CantorArchiver` class used for archiving (and restoring) namespaces to `.tar.gz` files. Archives are tar files to allow for separating archives into more manageable chunks.