### PR TITLE
Add queries to archive parameters

### DIFF
--- a/cantor-archive/src/main/java/com/salesforce/cantor/archive/EventsArchiver.java
+++ b/cantor-archive/src/main/java/com/salesforce/cantor/archive/EventsArchiver.java
@@ -9,6 +9,7 @@ package com.salesforce.cantor.archive;
 
 import com.google.protobuf.ByteString;
 import com.salesforce.cantor.Events;
+import com.salesforce.cantor.common.EventsPreconditions;
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
 import org.apache.commons.compress.archivers.ArchiveOutputStream;
@@ -18,6 +19,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static com.salesforce.cantor.common.CommonPreconditions.checkArgument;
@@ -28,20 +30,27 @@ public class EventsArchiver extends AbstractBaseArchiver {
     public static final long MIN_CHUNK_MILLIS = TimeUnit.MINUTES.toMillis(1);
     public static final long MAX_CHUNK_MILLIS = TimeUnit.MINUTES.toMillis(60);
 
-    public static void archive(final Events events, final String namespace, final long startTimestampMillis,
-                               final long endTimestampMillis, final long chunkMillis, final Path destination) throws IOException {
+    public static void archive(final Events events,
+                               final String namespace,
+                               final long startTimestampMillis,
+                               final long endTimestampMillis,
+                               final Map<String, String> metadataQuery,
+                               final Map<String, String> dimensionsQuery,
+                               final long chunkMillis,
+                               final Path destination) throws IOException {
         checkArchiveArguments(events, namespace, destination);
-        checkArgument(startTimestampMillis > 0, "start timestamp must be positive");
-        checkArgument(startTimestampMillis < endTimestampMillis, "start timestamp must be before end timestamp");
         checkArgument(chunkMillis >= MIN_CHUNK_MILLIS, "archive chunk millis must be greater than " + MIN_CHUNK_MILLIS);
         checkArgument(chunkMillis <= MAX_CHUNK_MILLIS, "archive chunk millis must be less than " + MAX_CHUNK_MILLIS);
+        EventsPreconditions.checkGet(namespace, startTimestampMillis, endTimestampMillis, metadataQuery, dimensionsQuery);
 
+        long startNanos = System.nanoTime();
+        long totalEventsArchived = 0;
         try (final ArchiveOutputStream archive = getArchiveOutputStream(destination)) {
             long chunkStart = startTimestampMillis;
             long chunkEnd = Math.min(chunkStart + chunkMillis, endTimestampMillis);
             while (chunkStart < endTimestampMillis) {
                 final String name = String.format("events-%s-%s-%s", namespace, chunkStart, chunkEnd);
-                final List<Events.Event> chunkEvents = events.get(namespace, chunkStart, chunkEnd, true);
+                final List<Events.Event> chunkEvents = events.get(namespace, chunkStart, chunkEnd, metadataQuery, dimensionsQuery, true);
                 // todo: can we do this differently? This doubles the memory we hold on to :(
                 final EventsChunk.Builder chunkBuilder = EventsChunk.newBuilder();
                 for (final Events.Event event : chunkEvents) {
@@ -57,7 +66,11 @@ public class EventsArchiver extends AbstractBaseArchiver {
                 writeArchiveEntry(archive, name, chunkBuilder.build().toByteArray());
                 chunkStart = chunkEnd;
                 chunkEnd = Math.min(chunkStart + chunkMillis, endTimestampMillis);
+                totalEventsArchived += chunkEvents.size();
             }
+        } finally {
+            logger.info("archiving {} events for namespace '{}' took {}s",
+                    totalEventsArchived, namespace, TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - startNanos));
         }
     }
 
@@ -65,9 +78,11 @@ public class EventsArchiver extends AbstractBaseArchiver {
         checkRestoreArguments(events, namespace, archiveFile);
         // create the namespace, in case the user hasn't already
         events.create(namespace);
+
+        long startNanos = System.nanoTime();
+        long totalEventsRestored = 0;
         try (final ArchiveInputStream archive = getArchiveInputStream(archiveFile)) {
             ArchiveEntry entry;
-            int total = 0;
             while ((entry = archive.getNextEntry()) != null) {
                 final EventsChunk chunk = EventsChunk.parseFrom(archive);
                 for (final EventsChunk.Event event : chunk.getEventsList()) {
@@ -78,9 +93,11 @@ public class EventsArchiver extends AbstractBaseArchiver {
                     }
                 }
                 logger.info("read {} entries from chunk {} ({} bytes) into {}", chunk.getEventsCount(), entry.getName(), entry.getSize(), namespace);
-                total += chunk.getEventsCount();
+                totalEventsRestored += chunk.getEventsCount();
             }
-            logger.info("restored {} events into namespace '{}' from archive file {}", total, namespace, archiveFile);
+        } finally {
+            logger.info("restoring {} events into namespace '{}' from archive file {} took {}s",
+                    totalEventsRestored, namespace, archiveFile, TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - startNanos));
         }
     }
 }

--- a/cantor-archive/src/test/java/com/salesforce/cantor/archive/EventsArchiverTest.java
+++ b/cantor-archive/src/test/java/com/salesforce/cantor/archive/EventsArchiverTest.java
@@ -24,7 +24,6 @@ import java.util.concurrent.TimeUnit;
 import static org.testng.Assert.*;
 
 public class EventsArchiverTest {
-
     @Test
     public void testArchiveEvents() throws IOException {
         final String basePath = Paths.get(System.getProperty("java.io.tmpdir"), "cantor-archive-sets-test", UUID.randomUUID().toString()).toString();
@@ -47,7 +46,7 @@ public class EventsArchiverTest {
         // archive events in 1 minute chunks
         Files.createDirectories(Paths.get(basePath, "output"));
         final Path outputPath = Paths.get(basePath, "output",  "test-archive.tar.gz");
-        EventsArchiver.archive(cantor.events(), namespace, standardStart, now, TimeUnit.MINUTES.toMillis(1L), outputPath);
+        EventsArchiver.archive(cantor.events(), namespace, standardStart, now, null, null, TimeUnit.MINUTES.toMillis(1L), outputPath);
         // check file was created and non-empty
         assertTrue(Files.exists(outputPath), "archive file missing");
         assertNotEquals(Files.size(outputPath), 0, "empty archive file shouldn't exist");
@@ -86,7 +85,7 @@ public class EventsArchiverTest {
 
         // archive overlap
         final Path overlapOutputPath = Paths.get(basePath, "output",  "test-overlap-archive.tar.gz");
-        EventsArchiver.archive(cantor.events(), namespace, overlapStart, overlapEnd, TimeUnit.MINUTES.toMillis(10L), overlapOutputPath);
+        EventsArchiver.archive(cantor.events(), namespace, overlapStart, overlapEnd, null, null, TimeUnit.MINUTES.toMillis(10L), overlapOutputPath);
         // restore overlap
         assertTrue(Files.exists(overlapOutputPath), "archive file missing");
         assertNotEquals(Files.size(overlapOutputPath), 0, "empty archive file shouldn't exist");
@@ -105,7 +104,7 @@ public class EventsArchiverTest {
         cantor.events().create(emptyNamespace);
         // archive empty
         final Path emptyOutputPath = Paths.get(basePath, "output", "test-empty-archive.tar.gz");
-        EventsArchiver.archive(cantor.events(), emptyNamespace, standardStart, now,  60_000L, emptyOutputPath);
+        EventsArchiver.archive(cantor.events(), emptyNamespace, standardStart, now, null, null,  60_000L, emptyOutputPath);
         assertTrue(Files.exists(emptyOutputPath), "archiving zero events should still produce file");
         // verify
         final String emptyVerificationNamespace = UUID.randomUUID().toString();
@@ -150,6 +149,7 @@ public class EventsArchiverTest {
         final Map<String, String> meta = new HashMap<>();
         for (int i = 0; i < ThreadLocalRandom.current().nextInt(0, 10); i++) {
             meta.put(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+            meta.put("meta-check", String.valueOf(ThreadLocalRandom.current().nextBoolean()));
         }
         return meta;
     }
@@ -158,6 +158,7 @@ public class EventsArchiverTest {
         final Map<String, Double> dim = new HashMap<>();
         for (int i = 0; i < ThreadLocalRandom.current().nextInt(0, 10); i++) {
             dim.put(UUID.randomUUID().toString(), ThreadLocalRandom.current().nextDouble());
+            dim.put("dim-check", ThreadLocalRandom.current().nextDouble());
         }
         return dim;
     }


### PR DESCRIPTION
Resolves #16 

Pretty simple, just passes through both parameters to `get(...)`. Added test cases to verify functionality.  