### PR TITLE
Reorganize Cantor Archiver and Add Support for Namespaceability

### DIFF
--- a/cantor-archive/src/main/java/com/salesforce/cantor/archive/file/AbstractBaseArchiverOnFile.java
+++ b/cantor-archive/src/main/java/com/salesforce/cantor/archive/file/AbstractBaseArchiverOnFile.java
@@ -16,13 +16,12 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import static com.salesforce.cantor.common.CommonPreconditions.checkArgument;
-import static com.salesforce.cantor.common.CommonPreconditions.checkString;
 
 public abstract class AbstractBaseArchiverOnFile {
     protected final String baseDirectory;
     protected final long chunkMillis;
 
-    // default to nothing for no sub directory
+    // nothing for no sub directory
     protected String subDirectory = "";
 
     protected AbstractBaseArchiverOnFile(final String baseDirectory) {
@@ -44,6 +43,10 @@ public abstract class AbstractBaseArchiverOnFile {
 
     protected void setSubDirectory(final String subDirectory) {
         this.subDirectory = (subDirectory != null) ? subDirectory : "";
+        final Path createDirectory = getArchiveLocation();
+        if (!createDirectory.toFile().exists() && !createDirectory.toFile().mkdirs()) {
+            throw new IllegalStateException("Failed to create sub directory for file archive: " + createDirectory);
+        }
     }
 
     protected void writeArchiveEntry(final ArchiveOutputStream archive, final String name, final byte[] bytes) throws IOException {
@@ -68,14 +71,12 @@ public abstract class AbstractBaseArchiverOnFile {
 
     protected boolean checkArchiveArguments(final Object instance, final String namespace, final Path destination) {
         checkArgument(instance != null, "null cantor instance, can't archive");
-        checkString(namespace, "null/empty namespace, can't archive");
         checkArgument(destination != null, "null destination, can't archive");
         return Files.notExists(destination) || destination.toFile().length() == 0;
     }
 
     protected void checkRestoreArguments(final Object instance, final String namespace, final Path archiveFile) {
         checkArgument(instance != null, "null objects, can't restore");
-        checkString(namespace, "null/empty namespace, can't restore");
         checkArgument(Files.exists(archiveFile), "can't locate archive file, can't restore: " + archiveFile);
     }
 

--- a/cantor-archive/src/main/java/com/salesforce/cantor/archive/file/ObjectsArchiverOnFile.java
+++ b/cantor-archive/src/main/java/com/salesforce/cantor/archive/file/ObjectsArchiverOnFile.java
@@ -18,18 +18,48 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static com.salesforce.cantor.common.CommonPreconditions.checkArgument;
+import static com.salesforce.cantor.common.CommonPreconditions.checkString;
 
 public class ObjectsArchiverOnFile extends AbstractBaseArchiverOnFile implements ObjectsArchiver {
     private static final Logger logger = LoggerFactory.getLogger(ObjectsArchiverOnFile.class);
     protected static final String archivePathFormat = "/archive-objects-%s";
+    private static final Pattern archiveRegexPattern = Pattern.compile("archive-objects-(?<namespace>.*)");
 
     public static final int chunkSize = 1_000;
 
     public ObjectsArchiverOnFile(final String baseDirectory) {
         super(baseDirectory);
+        setSubDirectory("objects");
+    }
+
+    @Override
+    public Collection<String> namespaces() throws IOException {
+        return Files.list(getArchiveLocation())
+                .map(ObjectsArchiverOnFile::getNamespace)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void create(final String namespace) throws IOException {
+        // no-op; creating an archive only happens during deletion of hot data
+    }
+
+    @Override
+    public void drop(final String namespace) throws IOException {
+        final Path archiveFile = getFileArchive(namespace);
+        checkArgument(archiveFile.toFile().exists(), "file archive does not exist: " + archiveFile);
+        if (!archiveFile.toFile().delete()) {
+            throw new IOException("failed to delete namespace archive: " + archiveFile.toString());
+        }
     }
 
     @Override
@@ -92,6 +122,14 @@ public class ObjectsArchiverOnFile extends AbstractBaseArchiverOnFile implements
     }
 
     protected Path getFileArchive(final String namespace) {
+        checkString(namespace, "null/empty namespace");
         return getFile(archivePathFormat, namespace);
+    }
+
+    // extracts namespace from a filename
+    protected static String getNamespace(final Path path) {
+        final String fileName = path.getFileName().toString();
+        final Matcher matcher = archiveRegexPattern.matcher(fileName);
+        return (matcher.matches()) ? matcher.group("namespace") : null;
     }
 }

--- a/cantor-archive/src/main/java/com/salesforce/cantor/archive/s3/ObjectsArchiverOnS3.java
+++ b/cantor-archive/src/main/java/com/salesforce/cantor/archive/s3/ObjectsArchiverOnS3.java
@@ -15,6 +15,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Collection;
 
 public class ObjectsArchiverOnS3 extends AbstractBaseArchiverOnFile implements ObjectsArchiver {
     private static final Logger logger = LoggerFactory.getLogger(ObjectsArchiverOnS3.class);
@@ -33,6 +34,22 @@ public class ObjectsArchiverOnS3 extends AbstractBaseArchiverOnFile implements O
 
     @Override
     public void restore(final Objects objects, final String namespace) throws IOException {
+        // not implemented yet
+    }
+
+    @Override
+    public Collection<String> namespaces() throws IOException {
+        // not implemented yet
+        return null;
+    }
+
+    @Override
+    public void create(final String namespace) throws IOException {
+        // not implemented yet
+    }
+
+    @Override
+    public void drop(final String namespace) throws IOException {
         // not implemented yet
     }
 }

--- a/cantor-archive/src/main/java/com/salesforce/cantor/archive/s3/SetsArchiverOnS3.java
+++ b/cantor-archive/src/main/java/com/salesforce/cantor/archive/s3/SetsArchiverOnS3.java
@@ -15,6 +15,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Collection;
 
 public class SetsArchiverOnS3 extends AbstractBaseArchiverOnFile implements SetsArchiver {
     private static final Logger logger = LoggerFactory.getLogger(SetsArchiverOnS3.class);
@@ -33,6 +34,22 @@ public class SetsArchiverOnS3 extends AbstractBaseArchiverOnFile implements Sets
 
     @Override
     public void restore(final Sets sets, final String namespace) throws IOException {
+        // not implemented yet
+    }
+
+    @Override
+    public Collection<String> namespaces() throws IOException {
+        // not implemented yet
+        return null;
+    }
+
+    @Override
+    public void create(final String namespace) throws IOException {
+        // not implemented yet
+    }
+
+    @Override
+    public void drop(final String namespace) throws IOException {
         // not implemented yet
     }
 }

--- a/cantor-misc/src/main/java/com/salesforce/cantor/misc/archivable/CantorArchiver.java
+++ b/cantor-misc/src/main/java/com/salesforce/cantor/misc/archivable/CantorArchiver.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2020, Salesforce.com, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
 package com.salesforce.cantor.misc.archivable;
 
 /**

--- a/cantor-misc/src/main/java/com/salesforce/cantor/misc/archivable/EventsArchiver.java
+++ b/cantor-misc/src/main/java/com/salesforce/cantor/misc/archivable/EventsArchiver.java
@@ -1,6 +1,14 @@
+/*
+ * Copyright (c) 2020, Salesforce.com, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
 package com.salesforce.cantor.misc.archivable;
 
 import com.salesforce.cantor.Events;
+import com.salesforce.cantor.Namespaceable;
 import com.salesforce.cantor.misc.archivable.impl.ArchivableEvents;
 
 import java.io.IOException;
@@ -9,7 +17,7 @@ import java.util.Map;
 /**
  * EventsArchiver is the contract used by {@link ArchivableEvents} when handling the archiving of events
  */
-public interface EventsArchiver {
+public interface EventsArchiver extends Namespaceable {
     /**
      * Will retrieve and archive all events before the provided timestamp.
      * <br><br>

--- a/cantor-misc/src/main/java/com/salesforce/cantor/misc/archivable/ObjectsArchiver.java
+++ b/cantor-misc/src/main/java/com/salesforce/cantor/misc/archivable/ObjectsArchiver.java
@@ -1,5 +1,13 @@
+/*
+ * Copyright (c) 2020, Salesforce.com, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
 package com.salesforce.cantor.misc.archivable;
 
+import com.salesforce.cantor.Namespaceable;
 import com.salesforce.cantor.Objects;
 import com.salesforce.cantor.misc.archivable.impl.ArchivableEvents;
 
@@ -8,7 +16,7 @@ import java.io.IOException;
 /**
  * ObjectsArchiver is the contract used by {@link ArchivableEvents} when handling archiving of {@link Objects}
  */
-public interface ObjectsArchiver {
+public interface ObjectsArchiver extends Namespaceable {
     /**
      * Will retrieve and archive a specific object by key.
      */

--- a/cantor-misc/src/main/java/com/salesforce/cantor/misc/archivable/SetsArchiver.java
+++ b/cantor-misc/src/main/java/com/salesforce/cantor/misc/archivable/SetsArchiver.java
@@ -1,5 +1,13 @@
+/*
+ * Copyright (c) 2020, Salesforce.com, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
 package com.salesforce.cantor.misc.archivable;
 
+import com.salesforce.cantor.Namespaceable;
 import com.salesforce.cantor.Sets;
 import com.salesforce.cantor.misc.archivable.impl.ArchivableEvents;
 
@@ -8,7 +16,7 @@ import java.io.IOException;
 /**
  * SetsArchiver is the contract used by {@link ArchivableEvents} when handling archiving of {@link Sets}
  */
-public interface SetsArchiver {
+public interface SetsArchiver extends Namespaceable {
     /**
      * Will retrieve and archive the provided set in a namespace.
      */

--- a/cantor-misc/src/main/java/com/salesforce/cantor/misc/archivable/impl/AbstractBaseArchivableNamespaceable.java
+++ b/cantor-misc/src/main/java/com/salesforce/cantor/misc/archivable/impl/AbstractBaseArchivableNamespaceable.java
@@ -8,12 +8,11 @@
 package com.salesforce.cantor.misc.archivable.impl;
 
 import com.salesforce.cantor.Namespaceable;
-import com.salesforce.cantor.misc.archivable.CantorArchiver;
 
 import java.io.IOException;
 import java.util.Collection;
 
-abstract class AbstractBaseArchivableNamespaceable<T extends Namespaceable, A extends CantorArchiver>
+abstract class AbstractBaseArchivableNamespaceable<T extends Namespaceable, A extends Namespaceable>
                 implements Namespaceable {
     private final T delegate;
     private final A archiveDelegate;
@@ -24,17 +23,17 @@ abstract class AbstractBaseArchivableNamespaceable<T extends Namespaceable, A ex
     }
 
     @Override
-    public final Collection<String> namespaces() throws IOException {
+    public Collection<String> namespaces() throws IOException {
         return getDelegate().namespaces();
     }
 
     @Override
-    public final void create(final String namespace) throws IOException {
+    public void create(final String namespace) throws IOException {
         getDelegate().create(namespace);
     }
 
     @Override
-    public final void drop(final String namespace) throws IOException {
+    public void drop(final String namespace) throws IOException {
         getDelegate().drop(namespace);
     }
 

--- a/cantor-misc/src/main/java/com/salesforce/cantor/misc/archivable/impl/AbstractBaseArchivableNamespaceable.java
+++ b/cantor-misc/src/main/java/com/salesforce/cantor/misc/archivable/impl/AbstractBaseArchivableNamespaceable.java
@@ -24,16 +24,23 @@ abstract class AbstractBaseArchivableNamespaceable<T extends Namespaceable, A ex
 
     @Override
     public Collection<String> namespaces() throws IOException {
-        return getDelegate().namespaces();
+        final Collection<String> namespaces = getDelegate().namespaces();
+        final Collection<String> archivedNamespaces = getArchiver().namespaces();
+        if (namespaces != null && archivedNamespaces != null) {
+            namespaces.addAll(archivedNamespaces);
+        }
+        return (namespaces != null) ? namespaces : archivedNamespaces;
     }
 
     @Override
     public void create(final String namespace) throws IOException {
+        getArchiver().create(namespace);
         getDelegate().create(namespace);
     }
 
     @Override
     public void drop(final String namespace) throws IOException {
+        getArchiver().drop(namespace);
         getDelegate().drop(namespace);
     }
 

--- a/cantor-misc/src/main/java/com/salesforce/cantor/misc/archivable/impl/ArchivableCantor.java
+++ b/cantor-misc/src/main/java/com/salesforce/cantor/misc/archivable/impl/ArchivableCantor.java
@@ -18,12 +18,10 @@ import org.slf4j.LoggerFactory;
 import static com.salesforce.cantor.common.CommonPreconditions.checkArgument;
 
 /**
- * The ArchivableCantor implementation is a wrapper around a delegate Cantor instance and an {@link CantorArchiver} reference.
- * The {@code delegate} is the main data-store with direct implementations of {@link Sets} and {@link Objects}.
- * The {@code archiveDelegate} is used to archive any events removed when calling {@link Events#expire} or
- * {@link Events#delete} for longer term storage.
- * <br/>
- * Future Work: Calls to retrieve data that has been archived will be loaded back into the {@code delegate} Cantor.
+ * The ArchivableCantor implementation is a wrapper around a delegate Cantor instance and a {@link CantorArchiver} reference.
+ * The {@code delegate} is the main data-store which is used directly for {@link Sets} and {@link Objects}.
+ * The {@code archiveDelegate} is used to archive any events removed when calling {@link Events#expire} for
+ * longer term storage.
  * <br/>
  * Use it like this:
  * <pre>
@@ -48,7 +46,7 @@ public class ArchivableCantor implements Cantor {
         //TODO: add support for ArchivableObjects and ArchivableSets
         this.objects = delegate.objects();
         this.sets = delegate.sets();
-        this.events = new ArchivableEvents(delegate.events(), archiver);
+        this.events = new ArchivableEvents(delegate.events(), archiver.events());
     }
 
     @Override

--- a/cantor-misc/src/main/java/com/salesforce/cantor/misc/archivable/impl/ArchivableEvents.java
+++ b/cantor-misc/src/main/java/com/salesforce/cantor/misc/archivable/impl/ArchivableEvents.java
@@ -20,8 +20,8 @@ import java.util.Set;
 /**
  * Wrapper class around a delegate Events instance, adding logging and time spent.
  */
-public class ArchivableEvents extends AbstractBaseArchivableNamespaceable<Events, CantorArchiver> implements Events {
-    public ArchivableEvents(final Events delegate, final CantorArchiver archiver) {
+public class ArchivableEvents extends AbstractBaseArchivableNamespaceable<Events, EventsArchiver> implements Events {
+    public ArchivableEvents(final Events delegate, final EventsArchiver archiver) {
         super(delegate, archiver);
     }
 
@@ -40,7 +40,7 @@ public class ArchivableEvents extends AbstractBaseArchivableNamespaceable<Events
                            final boolean includePayloads,
                            final boolean ascending,
                            final int limit) throws IOException {
-        getArchiver().events().restore(getDelegate(), namespace, startTimestampMillis, endTimestampMillis);
+        getArchiver().restore(getDelegate(), namespace, startTimestampMillis, endTimestampMillis);
         return getDelegate().get(namespace,
                         startTimestampMillis,
                         endTimestampMillis,
@@ -76,7 +76,7 @@ public class ArchivableEvents extends AbstractBaseArchivableNamespaceable<Events
                                              final Map<String, String> dimensionsQuery,
                                              final int aggregateIntervalMillis,
                                              final AggregationFunction aggregationFunction) throws IOException {
-        getArchiver().events().restore(getDelegate(), namespace, startTimestampMillis, endTimestampMillis);
+        getArchiver().restore(getDelegate(), namespace, startTimestampMillis, endTimestampMillis);
         return getDelegate().aggregate(namespace,
                         dimension,
                         startTimestampMillis,
@@ -95,7 +95,7 @@ public class ArchivableEvents extends AbstractBaseArchivableNamespaceable<Events
                                 final long endTimestampMillis,
                                 final Map<String, String> metadataQuery,
                                 final Map<String, String> dimensionsQuery) throws IOException {
-        getArchiver().events().restore(getDelegate(), namespace, startTimestampMillis, endTimestampMillis);
+        getArchiver().restore(getDelegate(), namespace, startTimestampMillis, endTimestampMillis);
         return getDelegate().metadata(namespace,
                         metadataKey,
                         startTimestampMillis,
@@ -108,7 +108,7 @@ public class ArchivableEvents extends AbstractBaseArchivableNamespaceable<Events
     @Override
     public void expire(final String namespace, final long endTimestampMillis) throws IOException {
         // archiving all before deletion
-        getArchiver().events().archive(getDelegate(),namespace, endTimestampMillis);
+        getArchiver().archive(getDelegate(), namespace, endTimestampMillis);
         getDelegate().delete(namespace, 0, endTimestampMillis, null, null);
     }
 }


### PR DESCRIPTION
Experimenting with the Cantor Archiver, adding support for the namespace calls. Also only passing the archiver instance instead of the top-level archiver to each file.