### PR TITLE
Add Performance Tests to Cantor

### DIFF
--- a/cantor-common/pom.xml
+++ b/cantor-common/pom.xml
@@ -24,6 +24,10 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
 
+    <properties>
+        <apache.verison>3.6.1</apache.verison>
+    </properties>
+
     <dependencies>
         <!-- CANTOR BASE -->
         <dependency>
@@ -45,6 +49,12 @@
             <version>${testng.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- COMMONS MATH3 -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-math3</artifactId>
+            <version>${apache.verison}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -52,7 +62,7 @@
             <extension>
                 <groupId>kr.motd.maven</groupId>
                 <artifactId>os-maven-plugin</artifactId>
-                <version>1.4.1.Final</version>
+                <version>1.6.0</version>
             </extension>
         </extensions>
 

--- a/cantor-common/src/test/java/com/salesforce/cantor/common/performance/AbstractBaseCantorPerformanceTest.java
+++ b/cantor-common/src/test/java/com/salesforce/cantor/common/performance/AbstractBaseCantorPerformanceTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2020, Salesforce.com, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.cantor.common.performance;
+
+import com.salesforce.cantor.Cantor;
+import org.apache.commons.math3.stat.descriptive.rank.Percentile;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.util.*;
+import java.util.stream.DoubleStream;
+
+public abstract class AbstractBaseCantorPerformanceTest {
+    protected Logger logger = LoggerFactory.getLogger(getClass());
+
+    protected abstract Cantor getCantor() throws IOException;
+
+    protected void printStatsTable(final String title, final Map<String, Percentile> percentiles) {
+        System.out.println("-----------------------------------------------------------------------------------------------");
+        System.out.printf("%20s|%7s %7s %7s %7s %7s %7s %7s %7s %7s%n", title, "Count", "Sum", "Avg", "Min", "Max", "P50", "P90", "P95", "P99");
+        System.out.println("-----------------------------------------------------------------------------------------------");
+
+        final File file = new File(this.getClass().getSimpleName() + "_" + title);
+        try (final OutputStream csvFile = new FileOutputStream(file)) {
+            csvFile.write(String.format("%s,Count,Sum,Avg,Min,Max,P50,P90,P95,P99%n", title).getBytes());
+            csvFile.flush();
+            for (final String type : percentiles.keySet()) {
+                final Percentile percentile = percentiles.get(type);
+                final double[] data = percentile.getData();
+                final DoubleSummaryStatistics summaryStatistics = new DoubleSummaryStatistics();
+                for (final double datum : data) {
+                    summaryStatistics.accept(datum);
+                }
+
+                System.out.printf("%20s|%7d %7.4f %7.4f %7.4f %7.4f %7.4f %7.4f %7.4f %7.4f%n",
+                    type,
+                    summaryStatistics.getCount(),
+                    summaryStatistics.getSum(),
+                    summaryStatistics.getAverage(),
+                    summaryStatistics.getMin(),
+                    summaryStatistics.getMax(),
+                    percentile.evaluate(50),
+                    percentile.evaluate(90),
+                    percentile.evaluate(95),
+                    percentile.evaluate(99)
+                );
+
+                csvFile.write(String.format("%s,%d,%f,%f,%f,%f,%f,%f,%f,%f%n",
+                    type,
+                    summaryStatistics.getCount(),
+                    summaryStatistics.getSum(),
+                    summaryStatistics.getAverage(),
+                    summaryStatistics.getMin(),
+                    summaryStatistics.getMax(),
+                    percentile.evaluate(50),
+                    percentile.evaluate(90),
+                    percentile.evaluate(95),
+                    percentile.evaluate(99)
+                ).getBytes());
+            }
+            csvFile.flush();
+
+            final Map<String, double[]> crossIterationPercentile = new TreeMap<>();
+            for (final String type : percentiles.keySet()) {
+                final Percentile percentile = percentiles.get(type);
+                final String key = type.substring(0, type.indexOf("-"));
+                crossIterationPercentile.compute(key, (k, value) -> (value == null)
+                        ? percentile.getData()
+                        : DoubleStream.concat(DoubleStream.of(value), DoubleStream.of(percentile.getData())).toArray());
+            }
+
+            for (final String type : crossIterationPercentile.keySet()) {
+                final Percentile percentile = new Percentile();
+                percentile.setData(crossIterationPercentile.get(type));
+                final DoubleSummaryStatistics summaryStatistics = new DoubleSummaryStatistics();
+                for (final double datum : percentile.getData()) {
+                    summaryStatistics.accept(datum);
+                }
+
+                System.out.printf("%20s|%7d %7.4f %7.4f %7.4f %7.4f %7.4f %7.4f %7.4f %7.4f%n",
+                        type,
+                        summaryStatistics.getCount(),
+                        summaryStatistics.getSum(),
+                        summaryStatistics.getAverage(),
+                        summaryStatistics.getMin(),
+                        summaryStatistics.getMax(),
+                        percentile.evaluate(50),
+                        percentile.evaluate(90),
+                        percentile.evaluate(95),
+                        percentile.evaluate(99)
+                );
+
+                csvFile.write(String.format("%s,%d,%f,%f,%f,%f,%f,%f,%f,%f%n",
+                        type,
+                        summaryStatistics.getCount(),
+                        summaryStatistics.getSum(),
+                        summaryStatistics.getAverage(),
+                        summaryStatistics.getMin(),
+                        summaryStatistics.getMax(),
+                        percentile.evaluate(50),
+                        percentile.evaluate(90),
+                        percentile.evaluate(95),
+                        percentile.evaluate(99)
+                ).getBytes());
+            }
+            csvFile.flush();
+        } catch (final IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/cantor-common/src/test/java/com/salesforce/cantor/common/performance/AbstractBaseEventsPerformanceTest.java
+++ b/cantor-common/src/test/java/com/salesforce/cantor/common/performance/AbstractBaseEventsPerformanceTest.java
@@ -39,7 +39,7 @@ public abstract class AbstractBaseEventsPerformanceTest extends AbstractBaseCant
         super.printStatsTable(result.getName(), this.percentiles);
     }
 
-    @Test
+    @Test(enabled = false)
     public void testManySmallEvents() throws IOException {
         final Events events = getEvents();
         final List<Events.Event> storedEvents = generateEvents(getManyCount(), 5, 10, 1024);
@@ -63,7 +63,7 @@ public abstract class AbstractBaseEventsPerformanceTest extends AbstractBaseCant
         }
     }
 
-    @Test
+    @Test(enabled = false)
     public void testFewLargeEvents() throws IOException {
         final Events events = getEvents();
         final List<Events.Event> storedEvents = generateEvents(getFewCount(), 25, 50, 1024 * 1024);
@@ -87,7 +87,7 @@ public abstract class AbstractBaseEventsPerformanceTest extends AbstractBaseCant
         }
     }
 
-    @Test
+    @Test(enabled = false)
     public void testFewSmallEvents() throws IOException {
         final Events events = getEvents();
         final List<Events.Event> storedEvents = generateEvents(getFewCount(), 5, 10, 1024);
@@ -111,7 +111,7 @@ public abstract class AbstractBaseEventsPerformanceTest extends AbstractBaseCant
         }
     }
 
-    @Test
+    @Test(enabled = false)
     public void testManyLargeEvents() throws IOException {
         final Events events = getEvents();
         final List<Events.Event> storedEvents = generateEvents(getManyCount(), 25, 50, 1024 * 1024);

--- a/cantor-common/src/test/java/com/salesforce/cantor/common/performance/AbstractBaseEventsPerformanceTest.java
+++ b/cantor-common/src/test/java/com/salesforce/cantor/common/performance/AbstractBaseEventsPerformanceTest.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) 2020, Salesforce.com, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.cantor.common.performance;
+
+import com.salesforce.cantor.Events;
+import org.apache.commons.math3.stat.descriptive.rank.Percentile;
+import org.testng.ITestResult;
+import org.testng.annotations.*;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+import static org.testng.Assert.assertFalse;
+
+/**
+ * Performance test for Cantor Events. At the end of each test statistics for store and retrieval will be output.
+ */
+public abstract class AbstractBaseEventsPerformanceTest extends AbstractBaseCantorPerformanceTest {
+    private final String namespace = UUID.randomUUID().toString();
+
+    private Map<String, Percentile> percentiles;
+
+    @BeforeMethod
+    public void before() throws Exception {
+        this.percentiles = new TreeMap<>();
+        getEvents().create(this.namespace);
+    }
+
+    @AfterMethod
+    public void after(final ITestResult result) throws Exception {
+        getEvents().drop(this.namespace);
+        super.printStatsTable(result.getName(), this.percentiles);
+    }
+
+    @Test
+    public void testManySmallEvents() throws IOException {
+        final Events events = getEvents();
+        final List<Events.Event> storedEvents = generateEvents(getManyCount(), 5, 10, 1024);
+        for (int iteration = 0; iteration < getIterations(); iteration++) {
+            getEvents().create(this.namespace);
+            // batch is a single
+            final Percentile storageBatchStats = doTestBatchStorageOfEvents(events, storedEvents);
+            this.percentiles.put(String.format("storeBatch%d-%d", getManyCount(), iteration), storageBatchStats);
+
+            final Percentile deletionStats = doTestDeleteOfEvents(events, storedEvents);
+            this.percentiles.put(String.format("delete%d-%d", getManyCount(), iteration), deletionStats);
+
+            final Percentile storageStats = doTestStorageOfEvents(events, storedEvents);
+            this.percentiles.put(String.format("store%d-%d", getManyCount(), iteration), storageStats);
+
+            final Percentile retrievalStats = doTestRetrievalOfEvents(events, storedEvents);
+            this.percentiles.put(String.format("get%d-%d", getManyCount(), iteration), retrievalStats);
+
+            final Percentile dropStats = doTestDropOfEvents(events);
+            this.percentiles.put(String.format("drop%d-%d", getManyCount(), iteration), dropStats);
+        }
+    }
+
+    @Test
+    public void testFewLargeEvents() throws IOException {
+        final Events events = getEvents();
+        final List<Events.Event> storedEvents = generateEvents(getFewCount(), 25, 50, 1024 * 1024);
+        for (int iteration = 0; iteration < getIterations(); iteration++) {
+            getEvents().create(this.namespace);
+            // batch is a single
+            final Percentile storageBatchStats = doTestBatchStorageOfEvents(events, storedEvents);
+            this.percentiles.put(String.format("storeBatch%d-%d", getManyCount(), iteration), storageBatchStats);
+
+            final Percentile deletionStats = doTestDeleteOfEvents(events, storedEvents);
+            this.percentiles.put(String.format("delete%d-%d", getManyCount(), iteration), deletionStats);
+
+            final Percentile storageStats = doTestStorageOfEvents(events, storedEvents);
+            this.percentiles.put(String.format("store%d-%d", getManyCount(), iteration), storageStats);
+
+            final Percentile retrievalStats = doTestRetrievalOfEvents(events, storedEvents);
+            this.percentiles.put(String.format("get%d-%d", getManyCount(), iteration), retrievalStats);
+
+            final Percentile dropStats = doTestDropOfEvents(events);
+            this.percentiles.put(String.format("drop%d-%d", getManyCount(), iteration), dropStats);
+        }
+    }
+
+    @Test
+    public void testFewSmallEvents() throws IOException {
+        final Events events = getEvents();
+        final List<Events.Event> storedEvents = generateEvents(getFewCount(), 5, 10, 1024);
+        for (int iteration = 0; iteration < getIterations(); iteration++) {
+            getEvents().create(this.namespace);
+            // batch is a single
+            final Percentile storageBatchStats = doTestBatchStorageOfEvents(events, storedEvents);
+            this.percentiles.put(String.format("storeBatch%d-%d", getManyCount(), iteration), storageBatchStats);
+
+            final Percentile deletionStats = doTestDeleteOfEvents(events, storedEvents);
+            this.percentiles.put(String.format("delete%d-%d", getManyCount(), iteration), deletionStats);
+
+            final Percentile storageStats = doTestStorageOfEvents(events, storedEvents);
+            this.percentiles.put(String.format("store%d-%d", getManyCount(), iteration), storageStats);
+
+            final Percentile retrievalStats = doTestRetrievalOfEvents(events, storedEvents);
+            this.percentiles.put(String.format("get%d-%d", getManyCount(), iteration), retrievalStats);
+
+            final Percentile dropStats = doTestDropOfEvents(events);
+            this.percentiles.put(String.format("drop%d-%d", getManyCount(), iteration), dropStats);
+        }
+    }
+
+    @Test
+    public void testManyLargeEvents() throws IOException {
+        final Events events = getEvents();
+        final List<Events.Event> storedEvents = generateEvents(getManyCount(), 25, 50, 1024 * 1024);
+        for (int iteration = 0; iteration < getIterations(); iteration++) {
+            getEvents().create(this.namespace);
+            // batch is a single
+            final Percentile storageBatchStats = doTestBatchStorageOfEvents(events, storedEvents);
+            this.percentiles.put(String.format("storeBatch%d-%d", getManyCount(), iteration), storageBatchStats);
+
+            final Percentile deletionStats = doTestDeleteOfEvents(events, storedEvents);
+            this.percentiles.put(String.format("delete%d-%d", getManyCount(), iteration), deletionStats);
+
+            final Percentile storageStats = doTestStorageOfEvents(events, storedEvents);
+            this.percentiles.put(String.format("store%d-%d", getManyCount(), iteration), storageStats);
+
+            final Percentile retrievalStats = doTestRetrievalOfEvents(events, storedEvents);
+            this.percentiles.put(String.format("get%d-%d", getManyCount(), iteration), retrievalStats);
+
+            final Percentile dropStats = doTestDropOfEvents(events);
+            this.percentiles.put(String.format("drop%d-%d", getManyCount(), iteration), dropStats);
+        }
+    }
+
+    // override the number of times the performance test runs
+    protected int getIterations() {
+        return 10;
+    }
+
+    // override change the count stored by a "many" performance test
+    protected int getManyCount() {
+        return 3_000;
+    }
+
+    // override change the count stored by a "few" performance test
+    protected int getFewCount() {
+        return 30;
+    }
+
+    private Percentile doTestDropOfEvents(final Events events) throws IOException {
+        logger.info("calling events.drop() for namespace {}", this.namespace);
+        final long initialTimestamp = System.nanoTime();
+        events.drop(this.namespace);
+        final long finalTimestamp = System.nanoTime();
+
+        logger.info("drop total duration: {}ms", TimeUnit.NANOSECONDS.toMillis(finalTimestamp - initialTimestamp));
+        final Percentile percentile = new Percentile();
+        percentile.setData(new double[] {TimeUnit.NANOSECONDS.toMillis(finalTimestamp - initialTimestamp)});
+        return percentile;
+    }
+
+    private Percentile doTestDeleteOfEvents(final Events events, final List<Events.Event> storedEvents) throws IOException {
+        logger.info("calling events.delete() for {} events in 100 event batches", storedEvents.size());
+        final double[] deletionStats = new double[(storedEvents.size() / 100) + 1];
+        final long initialTimestamp = System.nanoTime();
+        for (int eventIndex = 99, statIndex = 0; eventIndex < storedEvents.size(); eventIndex += 100, statIndex++) {
+            final Events.Event batchStart = storedEvents.get(eventIndex - 99);
+            final Events.Event batchEnd = storedEvents.get(Math.min(eventIndex, storedEvents.size() - 1));
+            logger.debug("calling events.delete() {}-{}", batchStart.getTimestampMillis(), batchEnd.getTimestampMillis());
+            final long startTimestamp = System.nanoTime();
+            events.delete(this.namespace, batchStart.getTimestampMillis(), batchEnd.getTimestampMillis(), null, null);
+            final long afterStoreTimestamp = System.nanoTime();
+
+            final long duration = TimeUnit.NANOSECONDS.toMillis(afterStoreTimestamp - startTimestamp);
+            deletionStats[statIndex] = duration;
+        }
+        final long finalTimestamp = System.nanoTime();
+
+        logger.info("deletion total duration: {}ms", TimeUnit.NANOSECONDS.toMillis(finalTimestamp - initialTimestamp));
+        logger.debug("event deletion durations: {}", Arrays.toString(deletionStats));
+        final Percentile percentile = new Percentile();
+        percentile.setData(deletionStats);
+        return percentile;
+    }
+
+    private Percentile doTestBatchStorageOfEvents(final Events events, final List<Events.Event> storedEvents) throws IOException {
+        logger.info("calling events.store(batch) for {} events in batches of 100", storedEvents.size());
+        final double[] storageStats = new double[(storedEvents.size() / 100) + 1];
+        final long initialTimestamp = System.nanoTime();
+        for (int eventIndex = 0, statIndex = 0; eventIndex < storedEvents.size(); eventIndex += 100, statIndex++) {
+            final List<Events.Event> batch = storedEvents.subList(eventIndex, Math.min(eventIndex + 100, storedEvents.size()));
+            logger.debug("calling events.store(batch) for {} events {}-{}", batch.size(), eventIndex, Math.min(eventIndex + 100, storedEvents.size() - 1));
+
+            final long startTimestamp = System.nanoTime();
+            events.store(this.namespace, batch);
+            final long afterStoreTimestamp = System.nanoTime();
+
+            final long duration = TimeUnit.NANOSECONDS.toMillis(afterStoreTimestamp - startTimestamp);
+            logger.debug("took {}ms to store 100 events", duration);
+            storageStats[statIndex] = duration;
+        }
+        final long finalTimestamp = System.nanoTime();
+
+        logger.info("batch store total duration: {}ms", TimeUnit.NANOSECONDS.toMillis(finalTimestamp - initialTimestamp));
+        logger.debug("raw event store durations: {}", Arrays.toString(storageStats));
+        final Percentile percentile = new Percentile();
+        percentile.setData(storageStats);
+        return percentile;
+    }
+
+    private Percentile doTestStorageOfEvents(final Events events, final List<Events.Event> storedEvents) throws IOException {
+        logger.info("calling events.store() for {} events", storedEvents.size());
+        final double[] storageStats = new double[storedEvents.size()];
+        final long initialTimestamp = System.nanoTime();
+        for (int eventIndex = 0; eventIndex < storedEvents.size(); eventIndex++) {
+
+            final long startTimestamp = System.nanoTime();
+            events.store(this.namespace, storedEvents.get(eventIndex));
+            final long afterStoreTimestamp = System.nanoTime();
+
+            final long duration = TimeUnit.NANOSECONDS.toMillis(afterStoreTimestamp - startTimestamp);
+            storageStats[eventIndex] = duration;
+        }
+        final long finalTimestamp = System.nanoTime();
+
+        logger.info("store total duration: {}ms", TimeUnit.NANOSECONDS.toMillis(finalTimestamp - initialTimestamp));
+        logger.debug("raw event store durations: {}", Arrays.toString(storageStats));
+        final Percentile percentile = new Percentile();
+        percentile.setData(storageStats);
+        return percentile;
+    }
+
+    private Percentile doTestRetrievalOfEvents(final Events events, final List<Events.Event> storedEvents) throws IOException {
+        logger.info("calling events.get() to retrieve {} events in 100 event batches", storedEvents.size());
+        final double[] storageStats = new double[(storedEvents.size() / 100) + 1];
+        final long initialTimestamp = System.nanoTime();
+        for (int eventIndex = 99, statIndex = 0; eventIndex < storedEvents.size(); eventIndex += 100, statIndex++) {
+            final Events.Event batchStart = storedEvents.get(eventIndex - 99);
+            final Events.Event batchEnd = storedEvents.get(Math.min(eventIndex, storedEvents.size() - 1));
+            final long startTimestamp = System.nanoTime();
+            events.get(this.namespace, batchStart.getTimestampMillis(), batchEnd.getTimestampMillis(), true);
+            final long afterStoreTimestamp = System.nanoTime();
+
+            final long duration = TimeUnit.NANOSECONDS.toMillis(afterStoreTimestamp - startTimestamp);
+            storageStats[statIndex] = duration;
+        }
+        final long finalTimestamp = System.nanoTime();
+
+        logger.info("retrieval total duration: {}ms", TimeUnit.NANOSECONDS.toMillis(finalTimestamp - initialTimestamp));
+        logger.debug("raw event retrieval durations: {}", Arrays.toString(storageStats));
+        final Percentile percentile = new Percentile();
+        percentile.setData(storageStats);
+        return percentile;
+    }
+
+    private List<Events.Event> generateEvents(final int eventCount, final int originRandom, final int boundRandom, final int payloadSize) {
+        final List<Events.Event> events = new ArrayList<>();
+        final int metadataCount = ThreadLocalRandom.current().nextInt(originRandom, boundRandom);
+        final int dimensionCount = ThreadLocalRandom.current().nextInt(originRandom, boundRandom);
+        long timestamp = System.currentTimeMillis();
+        for (int i = 0; i < eventCount; ++i) {
+            final Map<String, String> metadata = getRandomMetadata(metadataCount);
+            final Map<String, Double> dimensions = getRandomDimensions(dimensionCount);
+            final byte[] payload = getRandomPayload(payloadSize);
+            timestamp += 1;
+            events.add(new Events.Event(timestamp, metadata, dimensions, payload));
+        }
+
+        return events;
+    }
+
+    private Map<String, Double> getRandomDimensions(final int count) {
+        final Map<String, Double> dimensions = new HashMap<>();
+        for (int i = 0; i < count; ++i) {
+            dimensions.put("random-keys-like-!@#$%^&*()_+=-/?,>,<`-are-all-accepted; " +
+                    "even really really unnecessarily long keys like this is acceptable!..." + i, ThreadLocalRandom.current().nextDouble());
+        }
+        return dimensions;
+    }
+
+    private Map<String, String> getRandomMetadata(final int count) {
+        final Map<String, String> metadata = new HashMap<>();
+        for (int i = 0; i < count; ++i) {
+            metadata.put("random-keys-like-!@#$%^&*()_+=-/?,>,<`-are-all-accepted; " +
+                    "even really really unnecessarily long keys like this is acceptable!..." + i, UUID.randomUUID().toString());
+        }
+        return metadata;
+    }
+
+    private byte[] getRandomPayload(final int size) {
+        final byte[] buffer = new byte[size];
+        new Random().nextBytes(buffer);
+        return buffer;
+    }
+
+    private Events getEvents() throws IOException {
+        return getCantor().events();
+    }
+}

--- a/cantor-common/src/test/java/com/salesforce/cantor/common/performance/AbstractBaseObjectsPerformanceTest.java
+++ b/cantor-common/src/test/java/com/salesforce/cantor/common/performance/AbstractBaseObjectsPerformanceTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2020, Salesforce.com, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.cantor.common.performance;
+
+import com.salesforce.cantor.Objects;
+import org.testng.annotations.*;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.testng.Assert.*;
+
+public abstract class AbstractBaseObjectsPerformanceTest extends AbstractBaseCantorPerformanceTest {
+    private final String namespace = UUID.randomUUID().toString();
+
+    @BeforeMethod
+    public void before() throws Exception {
+        getObjects().create(this.namespace);
+    }
+
+    @AfterMethod
+    public void after() throws Exception {
+        getObjects().drop(this.namespace);
+    }
+
+    // override to store less (for impls that storing is more expensive) by setting to less than 1
+    protected double getStoreMagnitude() {
+        return 1.0D;
+    }
+
+    @Test
+    public void testBadInput() throws Exception {
+        final Objects objects = getObjects();
+
+        assertThrows(IllegalArgumentException.class, () -> objects.store(this.namespace, null, new byte[0]));
+        assertThrows(IllegalArgumentException.class, () -> objects.store(this.namespace, "", new byte[0]));
+        assertThrows(IllegalArgumentException.class, () -> objects.store(this.namespace, "abc", null));
+
+        assertThrows(IllegalArgumentException.class, () -> objects.get(this.namespace, (String) null));
+        assertThrows(IllegalArgumentException.class, () -> objects.get(this.namespace, ""));
+        assertThrows(IllegalArgumentException.class, () -> objects.get(this.namespace, (Collection<String>) null));
+
+        assertThrows(IllegalArgumentException.class, () -> objects.delete(this.namespace, (String) null));
+        assertThrows(IllegalArgumentException.class, () -> objects.delete(this.namespace, ""));
+        assertThrows(IllegalArgumentException.class, () -> objects.delete(this.namespace, (Collection<String>) null));
+
+        // trying to store an object in a this.namespace that is not created yet should throw ioexception
+        assertThrows(IOException.class, () -> objects.store(UUID.randomUUID().toString(), "foo", "bar".getBytes()));
+    }
+
+    @Test
+    public void testNamespaces() throws Exception {
+        final Objects objects = getObjects();
+        final List<String> namespaces = new ArrayList<>();
+        for (int i = 0; i < 10; ++i) {
+            final String namespace = UUID.randomUUID().toString();
+            namespaces.add(namespace);
+            assertFalse(objects.namespaces().contains(namespace));
+
+            objects.create(namespace);
+            assertTrue(objects.namespaces().contains(namespace));
+        }
+
+        for (final String namespace : namespaces) {
+            objects.drop(namespace);
+            assertFalse(objects.namespaces().contains(namespace));
+        }
+    }
+
+    @Test
+    public void testStoreGetDelete() throws Exception {
+        final Objects objects = getObjects();
+
+        final String key = UUID.randomUUID().toString();
+        final byte[] value = UUID.randomUUID().toString().getBytes();
+
+        assertNull(objects.get(this.namespace, key));
+        assertFalse(objects.delete(this.namespace, key));
+        objects.store(this.namespace, key, value);
+        assertEquals(value, objects.get(this.namespace, key));
+        assertTrue(objects.delete(this.namespace, key));
+        assertNull(objects.get(this.namespace, key));
+
+        final Map<String, byte[]> batch = new HashMap<>(100);
+        storeRandom(objects, this.namespace, batch, 100);
+
+        for (final String k : batch.keySet()) {
+            assertEquals(batch.get(k), objects.get(this.namespace, k));
+        }
+
+        objects.delete(this.namespace, batch.keySet());
+        for (final String k : batch.keySet()) {
+            assertNull(objects.get(this.namespace, k));
+        }
+    }
+
+    @Test
+    public void testStoreGetBatch() throws Exception {
+        final Objects objects = getObjects();
+
+        final Map<String, byte[]> empty = objects.get(this.namespace, Collections.emptyList());
+        assertTrue(empty.isEmpty());
+
+        final Map<String, byte[]> kvs = new HashMap<>();
+        for (int i = 0; i < 100; ++i) {
+            final String key = UUID.randomUUID().toString();
+            final byte[] value = UUID.randomUUID().toString().getBytes();
+            kvs.put(key, value);
+        }
+
+        for (final Map.Entry<String, byte[]> entry : kvs.entrySet()) {
+            assertNull(objects.get(this.namespace, entry.getKey()));
+        }
+        objects.store(this.namespace, kvs);
+        final Map<String, byte[]> results = objects.get(this.namespace, kvs.keySet());
+        assertEquals(kvs.size(), results.size());
+        for (final Map.Entry<String, byte[]> entry : kvs.entrySet()) {
+            assertEquals(results.get(entry.getKey()), entry.getValue());
+        }
+        objects.delete(this.namespace, kvs.keySet());
+        for (final Map.Entry<String, byte[]> entry : kvs.entrySet()) {
+            assertNull(objects.get(this.namespace, entry.getKey()));
+        }
+    }
+
+    @Test
+    public void testStoreKeys() throws Exception {
+        final Objects objects = getObjects();
+
+        final Map<String, byte[]> empty = objects.get(this.namespace, Collections.emptyList());
+        assertTrue(empty.isEmpty());
+
+        final Map<String, byte[]> kvs = new HashMap<>();
+        for (int i = 0; i < 100; ++i) {
+            final String key = UUID.randomUUID().toString();
+            final byte[] value = UUID.randomUUID().toString().getBytes();
+            kvs.put(key, value);
+        }
+
+        for (final Map.Entry<String, byte[]> entry : kvs.entrySet()) {
+            assertNull(objects.get(this.namespace, entry.getKey()));
+        }
+        objects.store(this.namespace, kvs);
+        final int count = ThreadLocalRandom.current().nextInt(1, 99);
+        final Collection<String> partialResults = objects.keys(this.namespace, 0, count);
+        assertEquals(partialResults.size(), count);
+
+        final Collection<String> results = objects.keys(this.namespace, 0, -1);
+        assertEquals(kvs.size(), results.size());
+        for (final Map.Entry<String, byte[]> entry : kvs.entrySet()) {
+            assertTrue(results.contains(entry.getKey()));
+        }
+        objects.delete(this.namespace, kvs.keySet());
+        for (final Map.Entry<String, byte[]> entry : kvs.entrySet()) {
+            assertNull(objects.get(this.namespace, entry.getKey()));
+        }
+    }
+
+    @Test
+    public void testSize() throws Exception {
+        final Objects objects = getObjects();
+
+        // delete everything, should leave 0 objects
+        objects.create(this.namespace);
+        objects.drop(this.namespace);
+        objects.create(this.namespace);
+
+        assertEquals(objects.size(this.namespace), 0);
+
+        // store and check size
+        final Map<String, byte[]> batch = new HashMap<>();
+        storeRandom(objects, this.namespace, batch, 1_000);
+        assertEquals(objects.size(this.namespace), batch.size());
+
+        // delete and check size
+        int removed = 0;
+        for (final String key : batch.keySet()) {
+            if (removed >= batch.size() / 2) {
+                break;
+            }
+            objects.delete(this.namespace, key);
+            removed++;
+        }
+        assertEquals(objects.size(this.namespace), batch.size() - removed);
+
+        // delete and check again
+        objects.delete(this.namespace, batch.keySet());
+        assertEquals(objects.size(this.namespace), 0);
+    }
+
+    private void storeRandom(final Objects objects,
+                             final String namespace,
+                             final Map<String, byte[]> map,
+                             final int times) throws IOException {
+        final double storeCount = Math.floor(times * getStoreMagnitude());
+        for (int i = 0; i < storeCount; i++) {
+            final String key = UUID.randomUUID().toString();
+            final byte[] value = UUID.randomUUID().toString().getBytes();
+            map.put(key, value);
+            objects.store(namespace, key, value);
+        }
+    }
+
+    private Objects getObjects() throws IOException {
+        return getCantor().objects();
+    }
+
+}

--- a/cantor-common/src/test/java/com/salesforce/cantor/common/performance/AbstractBaseSetsPerformanceTest.java
+++ b/cantor-common/src/test/java/com/salesforce/cantor/common/performance/AbstractBaseSetsPerformanceTest.java
@@ -1,0 +1,611 @@
+/*
+ * Copyright (c) 2020, Salesforce.com, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.cantor.common.performance;
+
+import com.salesforce.cantor.Sets;
+import org.testng.annotations.*;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.*;
+
+public abstract class AbstractBaseSetsPerformanceTest extends AbstractBaseCantorPerformanceTest {
+    private final String namespace = UUID.randomUUID().toString();
+
+    @BeforeMethod
+    public void before() throws Exception {
+        getSets().create(this.namespace);
+    }
+
+    @AfterMethod
+    public void after() throws Exception {
+        getSets().drop(this.namespace);
+    }
+
+    @Test
+    public void testNamespaces() throws Exception {
+        final Sets sets = getSets();
+        final List<String> namespaces = new ArrayList<>();
+        for (int i = 0; i < 10; ++i) {
+            final String namespace = UUID.randomUUID().toString();
+            namespaces.add(namespace);
+            assertFalse(sets.namespaces().contains(namespace));
+
+            sets.create(namespace);
+            assertTrue(sets.namespaces().contains(namespace));
+        }
+
+        for (final String namespace : namespaces) {
+            sets.drop(namespace);
+            assertFalse(sets.namespaces().contains(namespace));
+        }
+    }
+    @Test
+    public void testMinMax() throws IOException {
+        final Sets sets = getSets();
+
+        final String setName = UUID.randomUUID().toString();
+        sets.add(this.namespace, setName, "min", Long.MIN_VALUE);
+        sets.add(this.namespace, setName, "zero", 0);
+        sets.add(this.namespace, setName, "max", Long.MAX_VALUE);
+
+        assertEquals(sets.get(this.namespace, setName).size(), 3);
+        assertEquals(sets.weight(this.namespace, setName, "min").longValue(), Long.MIN_VALUE);
+        assertEquals(sets.weight(this.namespace, setName, "zero").longValue(), 0);
+        assertEquals(sets.weight(this.namespace, setName, "max").longValue(), Long.MAX_VALUE);
+    }
+
+//    @Test
+    public void testConcurrency() throws Exception {
+        final Sets sets = getSets();
+        final String setName = UUID.randomUUID().toString();
+        final ExecutorService executor = Executors.newCachedThreadPool();
+        final int entriesCount = 1000;
+        final int producersCount = 10;
+        final int consumersCount = 10;
+        final AtomicInteger producedCount = new AtomicInteger(0);
+        final AtomicInteger consumedCount = new AtomicInteger(0);
+        // producers
+        for (int i = 0; i < producersCount; ++i) {
+            executor.submit(() -> {
+                for (int j = 0; j < entriesCount / producersCount; ++j) {
+                    try {
+                        sets.add(this.namespace, setName, UUID.randomUUID().toString(), ThreadLocalRandom.current().nextLong());
+                        producedCount.incrementAndGet();
+                        logger.info("finished producing {} entries.", producedCount.get());
+                    } catch (IOException e) {
+                        logger.warn("exception caught", e);
+                        j--;
+                    }
+                }
+            });
+        }
+        // consumers
+        for (int i = 0; i < consumersCount; ++i) {
+            executor.submit(() -> {
+                while (true) {
+                    try {
+                        if (sets.size(this.namespace, setName) == 0) {
+                            break;
+                        }
+                        final Map<String, Long> entries = sets.pop(this.namespace, setName, 0, 10);
+                        consumedCount.addAndGet(entries.size());
+                        logger.info("consumed {} entries", consumedCount.get());
+                    } catch (IOException e) {
+                        logger.warn("exception caught", e);
+                    }
+                    logger.info("finished consuming {} entries.", consumedCount.get());
+                }
+            });
+        }
+        executor.shutdown();
+        executor.awaitTermination(1, TimeUnit.MINUTES);
+        assertEquals(producedCount.get(), entriesCount, "total number of entries produced is incorrect");
+        assertEquals(consumedCount.get(), producedCount.get(), "produced entries != consumed entries");
+    }
+
+    @Test
+    public void testAdd() throws IOException {
+        final Sets sets = getSets();
+
+        // test bad add() input
+        assertThrows(IllegalArgumentException.class, () -> sets.add(namespace, null, "e", 0L));
+        assertThrows(IllegalArgumentException.class, () -> sets.add(namespace, "", "e", 0L));
+        assertThrows(IllegalArgumentException.class, () -> sets.add(namespace, "k", null, 0L));
+        assertThrows(IllegalArgumentException.class, () -> sets.add(namespace, "k", "", 0L));
+
+        assertThrows(IOException.class, () -> sets.add(UUID.randomUUID().toString(), "foo", "bar"));
+
+        // test single add()
+        final String singleAddSetKey = UUID.randomUUID().toString();
+        final int singleAddCount = getCount(100, 200);
+        final List<String> singleAddKeys = addRandoms(namespace, sets, singleAddSetKey, singleAddCount);
+
+        final Map<String, Long> singleAddKeysWeights = sets.get(namespace, singleAddSetKey, 0, singleAddCount, 0, -1, true);
+        assertEquals(singleAddKeysWeights.size(), singleAddCount, "get() should return all the entries added");
+        for (int i = 0; i < singleAddKeys.size(); i++) {
+            final String keyI = singleAddKeys.get(i);
+            final Long valI = singleAddKeysWeights.get(keyI);
+            assertNotNull(valI, "get() didn't return weight for key=" + keyI);
+            assertEquals(valI.longValue(), i, "entries were added with weight in order, should match");
+        }
+
+        // test batch add()
+        final String batchAddSetKey = UUID.randomUUID().toString();
+        final int batchAddCount = getCount(100, 500);
+        final long minWeight = 1_000, maxWeight = 2_000;
+
+        final Map<String, Long> batchAddEntries = getRandoms(batchAddCount).stream()
+                .collect(Collectors.toMap(Function.identity(), (s) -> ThreadLocalRandom.current().nextLong(minWeight, maxWeight)));
+        sets.add(namespace, batchAddSetKey, batchAddEntries);
+
+        final Map<String, Long> batchAddKeysWeights = sets.get(namespace, batchAddSetKey, minWeight, maxWeight, 0, -1, true);
+        assertEquals(batchAddKeysWeights.size(), batchAddEntries.size(), "get() didn't return all entries added");
+        for (Map.Entry<String, Long> entry : batchAddKeysWeights.entrySet()) {
+            assertTrue(batchAddEntries.containsKey(entry.getKey()), "get() didn't return weight for key=" + entry.getKey());
+            assertEquals(entry.getValue(), batchAddEntries.get(entry.getKey()), "get() didn't return correct weight for key=" + entry.getKey());
+        }
+
+        // test noop add()
+        final String noopAddKey = UUID.randomUUID().toString();
+        addRandoms(namespace, sets, noopAddKey, getCount(1, 100));
+        final Map<String, Long> before = sets.get(namespace, noopAddKey, Long.MIN_VALUE, Long.MAX_VALUE, 0, -1, true);
+        sets.add(namespace, noopAddKey, Collections.emptyMap());
+        final Map<String, Long> after = sets.get(namespace, noopAddKey, Long.MIN_VALUE, Long.MAX_VALUE, 0, -1, true);
+        assertEqualsDeep(after, before, "noop add shouldn't have added anything");
+    }
+
+    @Test
+    public void testGet() throws IOException {
+        final Sets sets = getSets();
+
+        final String setKey = UUID.randomUUID().toString();
+        final int totalKeysCount = getCount(100, 300);
+        final List<String> randomKeys = addRandoms(namespace, sets, setKey, totalKeysCount);
+
+        // test bad get() input
+        assertThrows(IllegalArgumentException.class, () -> sets.get(namespace, null, 0, 1, 0, -1, true));  // null set should throw
+        assertThrows(IllegalArgumentException.class, () -> sets.get(namespace, "", 0, 1, 0, -1, true));  // empty set should throw
+        assertThrows(IllegalArgumentException.class, () -> sets.get(namespace, "s", 0, -1, 0, -1, true)); // max < min should throw
+        assertThrows(IllegalArgumentException.class, () -> sets.get(namespace, "s", 0, 1, 0, -2, true)); // -2 count should throw
+        assertThrows(IllegalArgumentException.class, () -> sets.get(namespace, "s", 0, 1, 2, -1, true)); // -1 count non-zero start should throw
+        assertThrows(IllegalArgumentException.class, () -> sets.get(namespace, "s", 0, 1, -1, -1, true)); // negative start should throw
+        assertThrows(IllegalArgumentException.class, () -> sets.get(namespace, "s", 0, 1, -1, 10, true)); // negative start should throw
+
+        // test ascending vs descending get()
+        final Map<String, Long> getAscending = sets.get(namespace, setKey, 0, totalKeysCount, 0, -1, true);
+        final Map<String, Long> getDescending = sets.get(namespace, setKey, 0, totalKeysCount, 0, -1, false);
+        assertEquals(getAscending.size(), getDescending.size(), "ascending vs descending shouldn't change result count");
+
+        final ListIterator<String> ascendingKeys = new ArrayList<>(getAscending.keySet()).listIterator();
+        final ListIterator<String> descendingKeys = new ArrayList<>(getDescending.keySet()).listIterator(getDescending.size());
+
+        while (ascendingKeys.hasNext()) {
+            assertTrue(descendingKeys.hasPrevious());
+            assertEquals(ascendingKeys.next(), descendingKeys.previous(), "entries should be in reverse for ascending vs descending");
+        }
+
+        final Map<String, Long> zeroTo10 = sets.get(namespace, setKey, 0, totalKeysCount, 0, 10, true);
+        final Map<String, Long> zeroTo20 = sets.get(namespace, setKey, 0, totalKeysCount, 0, 20, true);
+        final Map<String, Long> fiftyToEnd = sets.get(namespace, setKey, 0, totalKeysCount, 50, totalKeysCount - 50, true);
+
+        assertEquals(zeroTo10.size(), 10, "10 count was specified, size should be 10");
+        assertEquals(zeroTo20.size(), 20, "10 count was specified, size should be 10");
+        assertEquals(fiftyToEnd.size(), totalKeysCount - 50, "50 to end was specified, size should be total - 50");
+
+        assertEquals(zeroTo10.keySet().iterator().next(), sets.first(namespace, setKey), "first key returned should be first in set");
+        assertEquals(zeroTo20.keySet().iterator().next(), sets.first(namespace, setKey), "first key returned should be first in set");
+        assertEquals(getLast(fiftyToEnd.keySet()), sets.last(namespace, setKey), "last key returned should be last in set");
+        assertTrue(zeroTo10.keySet().stream().allMatch(zeroTo20::containsKey), "everything in 0-10 should also be in 0-20");
+        assertTrue(fiftyToEnd.keySet().stream().noneMatch(zeroTo20::containsKey), "nothing in 0-20 should be in 50-100");
+
+        // test min/max
+        final Map<String, Long> min25 = sets.get(namespace, setKey, 25, totalKeysCount, 0, -1, true);
+        assertTrue(min25.values().stream().allMatch(w -> w >= 25), "all weights should be 25 or over");
+
+        final Map<String, Long> max24 = sets.get(namespace, setKey, 0, 24, 0, -1, true);
+        assertTrue(max24.values().stream().allMatch(w -> w < 25), "all weights should be under 25");
+
+        final Map<String, Long> twenties = sets.get(namespace, setKey, 20, 29, 0, -1, true);
+        assertTrue(twenties.values().stream().allMatch(w -> w >= 20 && w <= 29), "all weights should be in the twenties");
+    }
+
+    @Test
+    public void testUnion() throws IOException {
+        final Sets sets = getSets();
+
+        final List<String> setNames = new ArrayList<>();
+        final Set<String> allEntries = new HashSet<>();
+        for (int i = 0; i < ThreadLocalRandom.current().nextInt(1, 100); ++i) {
+            final String setName = UUID.randomUUID().toString();
+            setNames.add(setName);
+            for (int j = 0; j < ThreadLocalRandom.current().nextInt(0, 1000); ++j) {
+                final String entry = j % 2 == 0 ? "common-entry" : UUID.randomUUID().toString();
+                allEntries.add(entry);
+                sets.add(namespace, setName, entry);
+            }
+        }
+
+        final Collection<String> returnedEntries = sets.union(namespace, setNames).keySet();
+        logger.info("all entries size: {} returned entries size for union: {}", allEntries.size(), returnedEntries.size());
+        assertEquals(returnedEntries.size(), allEntries.size());
+    }
+
+//    @Test
+    public void testIntersect() throws IOException {
+        final Sets sets = getSets();
+
+        final List<String> setNames = new ArrayList<>();
+        final Set<String> allEntries = new HashSet<>();
+        int weight = 0;
+        final String commonEntry = UUID.randomUUID().toString();
+        allEntries.add(commonEntry);
+        for (int i = 0; i < ThreadLocalRandom.current().nextInt(1, 100); ++i) {
+            final String setName = UUID.randomUUID().toString();
+            setNames.add(setName);
+            sets.add(namespace, setName, commonEntry);
+            for (int j = 0; j < ThreadLocalRandom.current().nextInt(2, 1000); ++j) {
+                final String entry = UUID.randomUUID().toString();
+                allEntries.add(entry);
+                sets.add(namespace, setName, entry, weight);
+            }
+        }
+
+        final Map<String, Long> returnedEntries = sets.intersect(namespace, setNames);
+        logger.info("all entries size: {} returned entries size for intersect: {}", allEntries.size(), returnedEntries.size());
+        logger.info("returned entries are: {}", returnedEntries.size());
+        // there is only one entry common in all sets
+        assertEquals(returnedEntries.keySet().size(), 1);
+    }
+
+    @Test
+    public void testPop() throws IOException {
+        final Sets sets = getSets();
+
+        final String setKey = UUID.randomUUID().toString();
+        final int totalKeysCount = getCount(100, 300);
+        addRandoms(namespace, sets, setKey, totalKeysCount);
+
+        // test bad pop() input
+        assertThrows(IllegalArgumentException.class, () -> sets.pop(namespace, null, 0, 1, 0, -1, true));  // null set should throw
+        assertThrows(IllegalArgumentException.class, () -> sets.pop(namespace, "", 0, 1, 0, -1, true));  // empty set should throw
+        assertThrows(IllegalArgumentException.class, () -> sets.pop(namespace, "s", 0, -1, 0, -1, true)); // max < min should throw
+        assertThrows(IllegalArgumentException.class, () -> sets.pop(namespace, "s", 0, 1, 0, -2, true)); // -2 count should throw
+        assertThrows(IllegalArgumentException.class, () -> sets.pop(namespace, "s", 0, 1, 2, -1, true)); // -1 count non-zero start should throw
+        assertThrows(IllegalArgumentException.class, () -> sets.pop(namespace, "s", 0, 1, -1, -1, true)); // negative start should throw
+        assertThrows(IllegalArgumentException.class, () -> sets.pop(namespace, "s", 0, 1, -1, 10, true)); // negative start should throw
+
+        assertEquals(sets.size(namespace, setKey), totalKeysCount);
+        // test ascending vs descending pop()
+        final Map<String, Long> popAscending = sets.pop(namespace, setKey, 0, totalKeysCount, 0, -1, true);
+        // all entries must have been removed
+        assertEquals(sets.size(namespace, setKey), 0);
+
+        final List<String> randomKeys2 = addRandoms(namespace, sets, setKey, totalKeysCount);
+
+        assertEquals(sets.size(namespace, setKey), totalKeysCount);
+        // test ascending vs descending pop()
+        final Map<String, Long> popDescending = sets.pop(namespace, setKey, 0, totalKeysCount, 0, -1, false);
+        assertEquals(sets.size(namespace, setKey), 0);
+
+        assertEquals(popAscending.size(), popDescending.size(), "ascending vs descending shouldn't change result count");
+
+        addRandoms(namespace, sets, setKey, totalKeysCount);
+        final Map<String, Long> zeroTo10 = sets.pop(namespace, setKey, 0, totalKeysCount, 0, 10, true);
+        final Map<String, Long> zeroTo20 = sets.pop(namespace, setKey, 0, totalKeysCount, 0, 20, true);
+        final Map<String, Long> thirtyToEnd = sets.pop(namespace, setKey, 0, totalKeysCount, 0, totalKeysCount - 30, true);
+        // nothing should be left in the set
+        assertEquals(sets.size(namespace, setKey), 0);
+
+        assertEquals(zeroTo10.size(), 10, "10 count was specified, size should be 10");
+        assertEquals(zeroTo20.size(), 20, "10 count was specified, size should be 10");
+        assertEquals(thirtyToEnd.size(), totalKeysCount - 30, "30 to end was specified, size should be total - 50");
+
+        addRandoms(namespace, sets, setKey, totalKeysCount);
+        // test min/max
+        final Map<String, Long> min25 = sets.pop(namespace, setKey, 25, totalKeysCount, 0, -1, true);
+        assertTrue(min25.values().stream().allMatch(w -> w >= 25), "all weights should be 25 or over");
+
+        addRandoms(namespace, sets, setKey, totalKeysCount);
+        final Map<String, Long> max24 = sets.pop(namespace, setKey, 0, 24, 0, -1, true);
+        assertTrue(max24.values().stream().allMatch(w -> w < 25), "all weights should be under 25");
+
+        final Map<String, Long> twenties = sets.pop(namespace, setKey, 20, 29, 0, -1, true);
+        assertTrue(twenties.values().stream().allMatch(w -> w >= 20 && w <= 29), "all weights should be in the twenties");
+    }
+
+    @Test
+    public void testKeys() throws IOException {
+        final Sets sets = getSets();
+
+        final String setKey = UUID.randomUUID().toString();
+        final int count = getExactCount(51, 100);
+        final List<String> randomKeys = addRandoms(namespace, sets, setKey, count);
+
+        // test bad entries() input
+        assertThrows(IllegalArgumentException.class, () -> sets.entries(namespace, null, 0, 1, 0, -1, true));  // null set should throw
+        assertThrows(IllegalArgumentException.class, () -> sets.entries(namespace, "", 0, 1, 0, -1, true));  // empty set should throw
+        assertThrows(IllegalArgumentException.class, () -> sets.entries(namespace, "s", 0, -1, 0, -1, true)); // max < min should throw
+        assertThrows(IllegalArgumentException.class, () -> sets.entries(namespace, "s", 0, 1, 0, -2, true)); // -2 count should throw
+        assertThrows(IllegalArgumentException.class, () -> sets.entries(namespace, "s", 0, 1, 2, -1, true)); // -1 count non-zero start should throw
+        assertThrows(IllegalArgumentException.class, () -> sets.entries(namespace, "s", 0, 1, -1, -1, true)); // negative start should throw
+        assertThrows(IllegalArgumentException.class, () -> sets.entries(namespace, "s", 0, 1, -1, 10, true)); // negative start should throw
+
+        // test ascending vs descending entries()
+        final List<String> keysAscending = new ArrayList<>(sets.entries(namespace, setKey, 0, count, 0, -1, true));
+        final List<String> keysDescending = new ArrayList<>(sets.entries(namespace, setKey, 0, count, 0, -1, false));
+        assertEquals(keysAscending.size(), keysDescending.size(), "ascending vs descending shouldn't change result count");
+
+        final ListIterator<String> ascendingKeys = keysAscending.listIterator();
+        final ListIterator<String> descendingKeys = keysDescending.listIterator(keysDescending.size());
+
+        while (ascendingKeys.hasNext()) {
+            assertTrue(descendingKeys.hasPrevious());
+            assertEquals(ascendingKeys.next(), descendingKeys.previous(), "entries should be in reverse for ascending vs descending");
+        }
+
+        final List<String> zeroTo10 = new ArrayList<>(sets.entries(namespace, setKey, 0, count, 0, 10, true));
+        final List<String> zeroTo20 = new ArrayList<>(sets.entries(namespace, setKey, 0, count, 0, 20, true));
+        final List<String> fiftyToEnd = new ArrayList<>(sets.entries(namespace, setKey, 0, count, 50, count - 50, true));
+
+        assertEquals(zeroTo10.size(), 10, "10 count was specified, size should be 10");
+        assertEquals(zeroTo20.size(), 20, "10 count was specified, size should be 10");
+        assertEquals(fiftyToEnd.size(), count - 50, "50 count was specified, size should be count - 50");
+
+        assertEquals(zeroTo10.get(0), sets.first(namespace, setKey), "first key returned should be first in set");
+        assertEquals(zeroTo20.get(0), sets.first(namespace, setKey), "first key returned should be first in set");
+        assertEquals(fiftyToEnd.get(fiftyToEnd.size() - 1), sets.last(namespace, setKey), "last key returned should be last in set");
+        assertTrue(zeroTo10.stream().allMatch(zeroTo20::contains), "everything in 0-10 should also be in 0-20");
+        assertTrue(fiftyToEnd.stream().noneMatch(zeroTo20::contains), "nothing in 0-20 should be in 50-100");
+
+        // test min/max
+        final List<String> min25 = new ArrayList<>(sets.entries(namespace, setKey, 25, count, 0, -1, true));
+        assertTrue(min25.stream().map(randomKeys::indexOf).allMatch(w -> w >= 25), "all weights should be 25 or over");
+
+        final List<String> max24 = new ArrayList<>(sets.entries(namespace, setKey, 0, 24, 0, -1, true));
+        assertTrue(max24.stream().map(randomKeys::indexOf).allMatch(w -> w < 25), "all weights should be under 25");
+
+        final List<String> twenties = new ArrayList<>(sets.entries(namespace, setKey, 20, 29, 0, -1, true));
+        assertTrue(twenties.stream().map(randomKeys::indexOf).allMatch(w -> w >= 20 && w <= 29), "all weights should be in the twenties");
+    }
+
+    @Test
+    public void testDelete() throws IOException {
+        final Sets sets = getSets();
+
+        final String setKey = UUID.randomUUID().toString();
+        final int count = getCount(50, 100);
+
+        // test delete specific entries
+        sets.add(namespace, setKey, "foobar", 123L);
+        sets.add(namespace, setKey, "fizzbuzz", 123L);
+        assertTrue(sets.delete(namespace, setKey, "foobar"));
+
+        assertEquals(sets.size(namespace, setKey), 1);
+        assertTrue(sets.delete(namespace, setKey, "fizzbuzz"));
+        assertFalse(sets.delete(namespace, setKey, "does-not-exist"));
+
+        // test delete() between for all
+        addRandoms(namespace, sets, setKey, count);
+        assertEquals(sets.size(namespace, setKey), count);
+        sets.delete(namespace, setKey, 0, count);
+        assertEquals(sets.size(namespace, setKey), 0);
+
+        // test delete() between for range outside of added
+        final List<String> randomKeys = addRandoms(namespace, sets, setKey, count);
+        assertEquals(sets.size(namespace, setKey), count);
+        sets.delete(namespace, setKey, count + 1, Long.MAX_VALUE);
+        assertEquals(sets.size(namespace, setKey), count);
+
+        // test delete() half
+        sets.delete(namespace, setKey, 0, count / 2);
+        final Map<String, Long> over50 = sets.get(namespace, setKey, 0, Long.MAX_VALUE, 0, -1, true);
+        assertTrue(over50.values().stream().allMatch(w -> w > count / 2), "removing lower half, weight shouldn't be under " + count / 2);
+
+        // empty set and verify
+        sets.delete(namespace, setKey, Long.MIN_VALUE, Long.MAX_VALUE);
+        assertEquals(sets.size(namespace, setKey), 0);
+
+        // test delete() in batch
+        final List<String> batchRandoms = addRandoms(namespace, sets, setKey, count);
+        assertEquals(sets.size(namespace, setKey), count);
+        sets.delete(namespace, setKey, batchRandoms);
+        final boolean anyPresent = sets.entries(namespace, setKey, Long.MIN_VALUE, Long.MAX_VALUE, 0, -1, true).stream().anyMatch(batchRandoms::contains);
+        assertFalse(anyPresent);
+    }
+
+    @Test
+    public void testSize() throws IOException {
+        final Sets sets = getSets();
+
+        final String setKey = UUID.randomUUID().toString();
+
+        assertEquals(sets.size(namespace, setKey), 0);
+
+        int total = 0;
+        for (int i = 0; i < 5; i++) {
+            final int count = ThreadLocalRandom.current().nextInt(0, 100);
+            addRandoms(namespace, sets, setKey, count);
+            assertEquals(sets.size(namespace, setKey), total + count, "set size should increase by count when count random entries added");
+            total += count;
+        }
+        assertEquals(sets.size(namespace, setKey), total, "set size should reflect total added");
+        assertNotEquals(sets.size(namespace, setKey), total + ThreadLocalRandom.current().nextInt(1, Integer.MAX_VALUE - total), "set size shouldn't match random int over total");
+    }
+
+    @Test
+    public void testFirst() throws IOException {
+        final Sets sets = getSets();
+
+        final String setKey = UUID.randomUUID().toString();
+
+        assertNull(sets.first(namespace, setKey));
+
+        final String lowest = UUID.randomUUID().toString();
+        sets.add(namespace, setKey, lowest, 0L);
+        assertEquals(sets.first(namespace, setKey), lowest, "lowest should be first");
+
+        final String highest = UUID.randomUUID().toString();
+        sets.add(namespace, setKey, highest, 100L);
+        assertEquals(sets.first(namespace, setKey), lowest, "lowest should be first");
+        assertNotEquals(sets.first(namespace, setKey), highest, "highest shouldn't be first");
+
+        final String middle = UUID.randomUUID().toString();
+        sets.add(namespace, setKey, middle, 50L);
+        assertEquals(sets.first(namespace, setKey), lowest, "lowest should be first");
+        assertNotEquals(sets.first(namespace, setKey), middle, "middle shouldn't be first");
+
+        assertTrue(sets.delete(namespace, setKey, lowest), "removing lowest shouldn't fail");
+        assertEquals(sets.first(namespace, setKey), middle, "removed lowest so middle should be first");
+
+        final String newLowest = UUID.randomUUID().toString();
+        sets.add(namespace, setKey, newLowest, 25L);
+        assertEquals(sets.first(namespace, setKey), newLowest, "new lowest added, should be first");
+        assertNotEquals(sets.first(namespace, setKey), middle, "middle is no longer first");
+    }
+
+    @Test
+    public void testLast() throws IOException {
+        final Sets sets = getSets();
+
+        final String setKey = UUID.randomUUID().toString();
+
+        assertNull(sets.last(namespace, setKey));
+
+        final String lowest = UUID.randomUUID().toString();
+        sets.add(namespace, setKey, lowest, 0L);
+        assertEquals(sets.last(namespace, setKey), lowest, "lowest should be last");
+
+        final String highest = UUID.randomUUID().toString();
+        sets.add(namespace, setKey, highest, 100L);
+        assertEquals(sets.last(namespace, setKey), highest, "highest should be last");
+        assertNotEquals(sets.last(namespace, setKey), lowest, "lowest shouldn't be last");
+
+        final String middle = UUID.randomUUID().toString();
+        sets.add(namespace, setKey, middle, 50L);
+        assertEquals(sets.last(namespace, setKey), highest, "highest should be last");
+        assertNotEquals(sets.last(namespace, setKey), middle, "middle shouldn't be last");
+
+        assertTrue(sets.delete(namespace, setKey, highest), "removing highest shouldn't fail");
+        assertEquals(sets.last(namespace, setKey), middle, "removed lowest so middle should be last");
+        assertNotEquals(sets.last(namespace, setKey), lowest, "lowest shouldn't be last");
+
+        final String newHighest = UUID.randomUUID().toString();
+        sets.add(namespace, setKey, newHighest, 75L);
+        assertEquals(sets.last(namespace, setKey), newHighest, "new highest added, should be last");
+        assertNotEquals(sets.last(namespace, setKey), middle, "middle is no longer last");
+    }
+
+    @Test
+    public void testWeight() throws IOException {
+        final Sets sets = getSets();
+
+        final String setKey = UUID.randomUUID().toString();
+
+        final List<String> keys = addRandoms(namespace, sets, setKey, getCount(100, 150));
+        for (int i = 0; i < keys.size(); i++) {
+            assertEquals(sets.weight(namespace, setKey, keys.get(i)), Long.valueOf((long) i), "weight should return the correct weight in order");
+        }
+
+        // sets.weight must return null if entry does not exist
+        assertNull(sets.weight(namespace, setKey, UUID.randomUUID().toString()));
+    }
+
+    @Test
+    public void testInc() throws IOException {
+        final Sets sets = getSets();
+
+        final String setKey = UUID.randomUUID().toString();
+
+        final String newEntry = UUID.randomUUID().toString();
+        final long randomWeight = ThreadLocalRandom.current().nextLong();
+        final long newEntryWeight = sets.inc(namespace, setKey, newEntry, randomWeight);
+        assertEquals(newEntryWeight, randomWeight);
+
+        final String entryToInc = UUID.randomUUID().toString();
+        final String controlEntry = UUID.randomUUID().toString();
+
+        sets.add(namespace, setKey, entryToInc, 0L);
+        sets.add(namespace, setKey, controlEntry, 0L);
+
+        long totalWeight = 0;
+        for (int i = 0; i < ThreadLocalRandom.current().nextInt(10, 100); i++) {
+            final long inc = ThreadLocalRandom.current().nextLong(0, 1000);
+            final long returnedWeight;
+            if (ThreadLocalRandom.current().nextBoolean()) {
+                returnedWeight = sets.inc(namespace, setKey, entryToInc, inc);
+                totalWeight += inc;
+            } else {
+                returnedWeight = sets.inc(namespace, setKey, entryToInc, inc * -1);
+                totalWeight -= inc;
+            }
+            assertEquals(returnedWeight, totalWeight);
+        }
+
+        final Long incrementedWeight = sets.weight(namespace, setKey, entryToInc);
+        assertNotNull(incrementedWeight, "entry should be in the set");
+        assertEquals(incrementedWeight.longValue(), totalWeight, "entry weight should reflect increments");
+
+        final Long unchangedWeight = sets.weight(namespace, setKey, controlEntry);
+        assertNotNull(unchangedWeight, "control entry should be in the set");
+        assertNotEquals(unchangedWeight, incrementedWeight, "incrementing shouldn't change control");
+        assertEquals(unchangedWeight.longValue(), 0L, "control weight should still be 0");
+    }
+
+    private int getCount(final int min, final int max) {
+        return (int) Math.floor(ThreadLocalRandom.current().nextInt(min, max) * getAddMagnitude());
+    }
+
+    private int getExactCount(final int min, final int max) {
+        return ThreadLocalRandom.current().nextInt(min, max);
+    }
+
+    private List<String> getRandoms(final int count) {
+        final List<String> randoms = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            final String key = UUID.randomUUID().toString();
+            randoms.add(key);
+        }
+
+        return randoms;
+    }
+
+    private List<String> addRandoms(final String namespace, final Sets sets, final String setKey, final int count) throws IOException {
+        final List<String> randoms = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            final String key = UUID.randomUUID().toString();
+            randoms.add(key);
+            sets.add(namespace, setKey, key, i);
+        }
+
+        return randoms;
+    }
+
+    private <T> T getLast(Collection<T> col) {
+        final Iterator<T> iterator = col.iterator();
+        T last = null;
+        while (iterator.hasNext()) {
+            last = iterator.next();
+        }
+
+        return last;
+    }
+
+    private double getAddMagnitude() {
+        return 1.0D;
+    }
+
+    private Sets getSets() throws IOException {
+        return getCantor().sets();
+    }
+}

--- a/cantor-grpc-protos/pom.xml
+++ b/cantor-grpc-protos/pom.xml
@@ -74,7 +74,7 @@
             <extension>
                 <groupId>kr.motd.maven</groupId>
                 <artifactId>os-maven-plugin</artifactId>
-                <version>1.4.1.Final</version>
+                <version>1.6.0</version>
             </extension>
         </extensions>
 

--- a/cantor-h2/src/test/java/com/salesforce/cantor/h2/performance/EventsOnH2PerformanceTest.java
+++ b/cantor-h2/src/test/java/com/salesforce/cantor/h2/performance/EventsOnH2PerformanceTest.java
@@ -9,6 +9,7 @@ package com.salesforce.cantor.h2.performance;
 
 import com.salesforce.cantor.Cantor;
 import com.salesforce.cantor.common.performance.AbstractBaseEventsPerformanceTest;
+import org.testng.annotations.Test;
 
 import java.io.IOException;
 

--- a/cantor-h2/src/test/java/com/salesforce/cantor/h2/performance/EventsOnH2PerformanceTest.java
+++ b/cantor-h2/src/test/java/com/salesforce/cantor/h2/performance/EventsOnH2PerformanceTest.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2020, Salesforce.com, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.cantor.h2.performance;
+
+import com.salesforce.cantor.Cantor;
+import com.salesforce.cantor.common.performance.AbstractBaseEventsPerformanceTest;
+
+import java.io.IOException;
+
+public class EventsOnH2PerformanceTest extends AbstractBaseEventsPerformanceTest {
+    @Override
+    public Cantor getCantor() throws IOException {
+        return H2Tests.getCantor();
+    }
+}

--- a/cantor-h2/src/test/java/com/salesforce/cantor/h2/performance/H2Tests.java
+++ b/cantor-h2/src/test/java/com/salesforce/cantor/h2/performance/H2Tests.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2020, Salesforce.com, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.cantor.h2.performance;
+
+import com.salesforce.cantor.Cantor;
+import com.salesforce.cantor.h2.CantorOnH2;
+
+import java.io.IOException;
+import java.util.UUID;
+
+class H2Tests {
+    private static final String path = "/tmp/cantor-perf-test-db/" + UUID.randomUUID().toString();
+
+    static Cantor getCantor() throws IOException {
+        return new CantorOnH2(path);
+    }
+}

--- a/cantor-s3/src/test/java/com/salesforce/cantor/s3/performance/EventsOnH2PerformanceTest.java
+++ b/cantor-s3/src/test/java/com/salesforce/cantor/s3/performance/EventsOnH2PerformanceTest.java
@@ -7,6 +7,8 @@
 
 package com.salesforce.cantor.s3.performance;
 
+import com.adobe.testing.s3mock.testng.S3Mock;
+import com.adobe.testing.s3mock.testng.S3MockListener;
 import com.amazonaws.auth.*;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3;
@@ -14,19 +16,20 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.salesforce.cantor.Cantor;
 import com.salesforce.cantor.common.performance.AbstractBaseEventsPerformanceTest;
 import com.salesforce.cantor.s3.CantorOnS3;
+import org.testng.annotations.Listeners;
 import org.testng.annotations.Test;
 
 import java.io.*;
 import java.util.Scanner;
 
-@Test(enabled = false)
+@Listeners(value = { S3MockListener.class })
 public class EventsOnH2PerformanceTest extends AbstractBaseEventsPerformanceTest {
     private static final String credentialsLocation = "/path/to/creds";
 
     @Override
     protected Cantor getCantor() throws IOException {
-        final AmazonS3 s3Client = createS3Client();
-        return new CantorOnS3(s3Client, "default");
+        final S3Mock s3Client = S3Mock.getInstance();
+        return new CantorOnS3(s3Client.createS3Client(), "default");
     }
 
     // insert real S3 client here to run integration testing
@@ -43,20 +46,5 @@ public class EventsOnH2PerformanceTest extends AbstractBaseEventsPerformanceTest
                     .withCredentials(new AWSStaticCredentialsProvider(sessionCredentials))
                     .build();
         }
-    }
-
-    @Override
-    public void testFewLargeEvents() throws IOException {
-//        super.testFewLargeEvents();
-    }
-
-    @Override
-    public void testFewSmallEvents() throws IOException {
-//        super.testFewSmallEvents();
-    }
-
-    @Override
-    public void testManyLargeEvents() throws IOException {
-//        super.testManyLargeEvents();
     }
 }

--- a/cantor-s3/src/test/java/com/salesforce/cantor/s3/performance/EventsOnH2PerformanceTest.java
+++ b/cantor-s3/src/test/java/com/salesforce/cantor/s3/performance/EventsOnH2PerformanceTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020, Salesforce.com, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.cantor.s3.performance;
+
+import com.amazonaws.auth.*;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.salesforce.cantor.Cantor;
+import com.salesforce.cantor.common.performance.AbstractBaseEventsPerformanceTest;
+import com.salesforce.cantor.s3.CantorOnS3;
+import org.testng.annotations.Test;
+
+import java.io.*;
+import java.util.Scanner;
+
+@Test(enabled = false)
+public class EventsOnH2PerformanceTest extends AbstractBaseEventsPerformanceTest {
+    private static final String credentialsLocation = "/path/to/creds";
+
+    @Override
+    protected Cantor getCantor() throws IOException {
+        final AmazonS3 s3Client = createS3Client();
+        return new CantorOnS3(s3Client, "default");
+    }
+
+    // insert real S3 client here to run integration testing
+    private AmazonS3 createS3Client() throws IOException {
+        final File s3File = new File(credentialsLocation);
+        try (final Scanner csvReader = new Scanner(new FileInputStream(s3File))) {
+            csvReader.useDelimiter(",");
+
+            final String keyId = csvReader.next();
+            final String accessKey = csvReader.next();
+
+            final AWSCredentials sessionCredentials = new BasicAWSCredentials(keyId, accessKey);
+            return AmazonS3ClientBuilder.standard().withRegion(Regions.US_WEST_2)
+                    .withCredentials(new AWSStaticCredentialsProvider(sessionCredentials))
+                    .build();
+        }
+    }
+
+    @Override
+    public void testFewLargeEvents() throws IOException {
+//        super.testFewLargeEvents();
+    }
+
+    @Override
+    public void testFewSmallEvents() throws IOException {
+//        super.testFewSmallEvents();
+    }
+
+    @Override
+    public void testManyLargeEvents() throws IOException {
+//        super.testManyLargeEvents();
+    }
+}


### PR DESCRIPTION
Only four basic cases right now.
1. testing a few small events
2. many small events
3. few large events
4. many large events

The events are transferred in 100 event batches to get a more accurate reading. Tests print the console their finding and also write the statistics to a csv file.

Note: Currently not testing any metadata/dimension queries.