### PR TITLE
Add S3 as a first class citizen

### DIFF
--- a/cantor-server/pom.xml
+++ b/cantor-server/pom.xml
@@ -65,6 +65,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!--CANTOR S3-->
+        <dependency>
+            <groupId>com.salesforce.cantor</groupId>
+            <artifactId>cantor-s3</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <!--CANTOR MISC-->
         <dependency>
             <groupId>com.salesforce.cantor</groupId>

--- a/cantor-server/src/main/java/com/salesforce/cantor/server/CantorEnvironment.java
+++ b/cantor-server/src/main/java/com/salesforce/cantor/server/CantorEnvironment.java
@@ -9,6 +9,7 @@ package com.salesforce.cantor.server;
 
 import com.google.common.base.Strings;
 import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 
 import java.util.Collections;
 import java.util.List;
@@ -32,6 +33,11 @@ public class CantorEnvironment {
 
     public String getStorageType() {
         return this.config.getString(Constants.CONFIG_ROOT_PREFIX + "." + Constants.CANTOR_STORAGE_TYPE);
+    }
+
+    public Config getConfig(final String config) {
+        checkArgument(!Strings.isNullOrEmpty(config), "null/empty config path");
+        return getIfHasPath(this.config::getConfig, getConfigPath(config), ConfigFactory.empty());
     }
 
     public List<? extends Config> getConfigAsList(final String config) {

--- a/cantor-server/src/main/java/com/salesforce/cantor/server/Constants.java
+++ b/cantor-server/src/main/java/com/salesforce/cantor/server/Constants.java
@@ -32,4 +32,11 @@ public class Constants {
     public static final String CANTOR_MYSQL_PORT = "port";
     public static final String CANTOR_MYSQL_USERNAME = "username";
     public static final String CANTOR_MYSQL_PASSWORD = "password";
+
+    // s3 configuration
+    public static final String CANTOR_S3_BUCKET_NAME = "bucket";
+    public static final String CANTOR_S3_BUCKET_REGION = "region";
+    public static final String CANTOR_S3_PROXY_HOST = "proxy.host";
+    public static final String CANTOR_S3_PROXY_PORT = "proxy.port";
+    public static final String CANTOR_S3_SETS_TYPE = "sets.type";
 }

--- a/cantor-server/src/main/resources/cantor-server.conf
+++ b/cantor-server/src/main/resources/cantor-server.conf
@@ -32,4 +32,10 @@ cantor {
       password=""
     }
   ]
+
+  s3 = {
+    bucket=bucket-placeholder
+    region=us-west-2
+    sets.type=h2
+  }
 }

--- a/env/dockers/cantor/cantor-server.conf
+++ b/env/dockers/cantor/cantor-server.conf
@@ -33,4 +33,10 @@ cantor {
       password=""
     }
   ]
+
+  s3 = {
+    bucket=bucket-placeholder
+    region=us-west-2
+    sets.type=h2
+  }
 }


### PR DESCRIPTION
Simple `CantorFactory` changes to add support for S3 in the conf file. Most configurations can be handle via AWS env variables, so little needs to be set in our configuration file.