### PR TITLE
Fixed bugs in cantor-metrics

### DIFF
--- a/cantor-metrics/src/main/java/com/salesforce/cantor/metrics/MetricCollectingObjects.java
+++ b/cantor-metrics/src/main/java/com/salesforce/cantor/metrics/MetricCollectingObjects.java
@@ -44,7 +44,7 @@ public class MetricCollectingObjects extends BaseMetricCollectingCantor implemen
 
     @Override
     public byte[] get(final String namespace, final String key) throws IOException {
-        return metrics(() -> this.delegate.get(namespace, key), "get", "cantor", bytes -> bytes.length);
+        return metrics(() -> this.delegate.get(namespace, key), "get", "cantor", bytes -> bytes != null ? bytes.length : 0);
     }
 
     @Override


### PR DESCRIPTION
the `get()` method under `MetricCollectingObjects` is throwing null pointer exceptions for test cases where it returns null instead of a byte array (see screenshot below), because null cannot be parsed into a metric value.
It does not cause tests or build to fail but I think it is better to get rid of the unneeded exception with a null check.
![screenshot](https://user-images.githubusercontent.com/79883147/113604397-10bb3900-95fa-11eb-95a2-88ed1c869e19.png)