### PR TITLE
Validate s3 client with a head call

### DIFF
--- a/cantor-s3/src/main/java/com/salesforce/cantor/s3/AbstractBaseS3Namespaceable.java
+++ b/cantor-s3/src/main/java/com/salesforce/cantor/s3/AbstractBaseS3Namespaceable.java
@@ -1,5 +1,7 @@
 package com.salesforce.cantor.s3;
 
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.HeadBucketRequest;
@@ -45,9 +47,9 @@ public abstract class AbstractBaseS3Namespaceable implements Namespaceable {
         try {
             // validate s3Client can connect; valid connection/credentials if exception isn't thrown
             this.s3Client.headBucket(new HeadBucketRequest(this.bucketName));
-        } catch (final AmazonS3Exception e) {
-            logger.warn("exception creating required buckets for objects on s3:", e);
-            throw new IOException("exception creating required buckets for objects on s3:", e);
+        } catch (final SdkClientException e) {
+            logger.warn("exception validating s3 client and bucket:", e);
+            throw new IOException("exception validating s3 client and bucket", e);
         }
 
         this.namespaceCache = CacheBuilder.newBuilder()

--- a/cantor-s3/src/main/java/com/salesforce/cantor/s3/AbstractBaseS3Namespaceable.java
+++ b/cantor-s3/src/main/java/com/salesforce/cantor/s3/AbstractBaseS3Namespaceable.java
@@ -2,6 +2,8 @@ package com.salesforce.cantor.s3;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
+import com.amazonaws.services.s3.model.HeadBucketRequest;
+import com.amazonaws.services.s3.model.ListObjectsV2Request;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.util.StringInputStream;
 import com.google.common.cache.*;
@@ -41,9 +43,8 @@ public abstract class AbstractBaseS3Namespaceable implements Namespaceable {
         this.bucketName = bucketName;
         this.namespaceLookupKey = S3Utils.getCleanKeyForNamespace(String.format("all-namespaces-%s", type));
         try {
-            if (!this.s3Client.doesBucketExistV2(this.bucketName)) {
-                throw new IllegalStateException("bucket does not exist: " + this.bucketName);
-            }
+            // validate s3Client can connect; valid connection/credentials if exception isn't thrown
+            this.s3Client.headBucket(new HeadBucketRequest(this.bucketName));
         } catch (final AmazonS3Exception e) {
             logger.warn("exception creating required buckets for objects on s3:", e);
             throw new IOException("exception creating required buckets for objects on s3:", e);


### PR DESCRIPTION
Checking if the bucket exists does not require the users credentials and as a result is a bad test of whether the s3Client is valid. Changing to a head call which is light-weight and validates the client's credentials if they need them.