### PR TITLE
Implement "dimensions" call for Cantor events

### DIFF
--- a/cantor-base/src/main/java/com/salesforce/cantor/Events.java
+++ b/cantor-base/src/main/java/com/salesforce/cantor/Events.java
@@ -314,6 +314,8 @@ public interface Events extends Namespaceable {
                          Map<String, String> dimensionsQuery) throws IOException;
 
     /**
+     * Get a list of events values where each event only contains the specified dimension, for events in the given
+     * namespace, with timestamp between the start and end, metadata and dimensions matching the given queries.
      *
      * @param namespace the namespace identifier
      * @param dimensionKey the given dimension key

--- a/cantor-base/src/main/java/com/salesforce/cantor/Events.java
+++ b/cantor-base/src/main/java/com/salesforce/cantor/Events.java
@@ -297,12 +297,13 @@ public interface Events extends Namespaceable {
      * the start and end, metadata and dimensions matching the given queries.
      *
      * @param namespace the namespace identifier
+     * @param metadataKey the given metadata key
      * @param startTimestampMillis start timestamp in milli-seconds
      * @param endTimestampMillis end timestamp in milli-seconds
      * @param metadataQuery map of string to string representing a query to run against events metadata
      * @param dimensionsQuery map of string to string representing a query to run against events dimensions
-     * @return map of timestamp to set of metadata values for all events in the namespace with timestamp
-     * between start/end and metadata/dimensions matching the query, bucketed for each interval
+     * @return set of metadata values for all events in the namespace with timestamp
+     * between start/end and metadata/dimensions matching the query
      * @throws IOException exception thrown from the underlying storage implementation
      */
     Set<String> metadata(String namespace,
@@ -311,6 +312,25 @@ public interface Events extends Namespaceable {
                          long endTimestampMillis,
                          Map<String, String> metadataQuery,
                          Map<String, String> dimensionsQuery) throws IOException;
+
+    /**
+     *
+     * @param namespace the namespace identifier
+     * @param dimensionKey the given dimension key
+     * @param startTimestampMillis start timestamp in milli-seconds
+     * @param endTimestampMillis end timestamp in milli-seconds
+     * @param metadataQuery map of string to string representing a query to run against events metadata
+     * @param dimensionsQuery map of string to string representing a query to run against events dimensions
+     * @return list of events where each event only contains the specified dimension - no payload or metadata is
+     * included, in the namespace with timestamp between start/end and metadata/dimensions matching the query
+     * @throws IOException exception thrown from the underlying storage implementation
+     */
+    List<Event> dimension(String namespace,
+                          String dimensionKey,
+                          long startTimestampMillis,
+                          long endTimestampMillis,
+                          Map<String, String> metadataQuery,
+                          Map<String, String> dimensionsQuery) throws IOException;
 
     /**
      * Expire all events with timestamp before the given end timestamp.

--- a/cantor-common/src/main/java/com/salesforce/cantor/common/EventsPreconditions.java
+++ b/cantor-common/src/main/java/com/salesforce/cantor/common/EventsPreconditions.java
@@ -49,6 +49,19 @@ public class EventsPreconditions extends CommonPreconditions {
         checkDimensionsQuery(dimensionsQuery);
     }
 
+    public static void checkDimension(final String namespace,
+                                      final String dimensionKey,
+                                      final long startTimestampMillis,
+                                      final long endTimestampMillis,
+                                      final Map<String, String> metadataQuery,
+                                      final Map<String, String> dimensionsQuery) {
+        checkNamespace(namespace);
+        checkString(dimensionKey);
+        checkTimestamps(startTimestampMillis, endTimestampMillis);
+        checkMetadataQuery(metadataQuery);
+        checkDimensionsQuery(dimensionsQuery);
+    }
+
     public static void checkExpire(final String namespace, final long endTimestampMillis) {
         checkNamespace(namespace);
         checkArgument(endTimestampMillis >= 0, "invalid end timestamp");

--- a/cantor-common/src/test/java/com/salesforce/cantor/common/AbstractBaseEventsTest.java
+++ b/cantor-common/src/test/java/com/salesforce/cantor/common/AbstractBaseEventsTest.java
@@ -8,7 +8,6 @@
 package com.salesforce.cantor.common;
 
 import com.salesforce.cantor.Events;
-import jdk.nashorn.internal.ir.annotations.Immutable;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;

--- a/cantor-common/src/test/java/com/salesforce/cantor/common/AbstractBaseEventsTest.java
+++ b/cantor-common/src/test/java/com/salesforce/cantor/common/AbstractBaseEventsTest.java
@@ -8,6 +8,7 @@
 package com.salesforce.cantor.common;
 
 import com.salesforce.cantor.Events;
+import jdk.nashorn.internal.ir.annotations.Immutable;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -388,6 +389,37 @@ public abstract class AbstractBaseEventsTest extends AbstractBaseCantorTest {
         assertEquals(metadataResults.size(), metadataValues.size());
         for (final String entry : metadataValues) {
             assertTrue(metadataResults.contains(entry));
+        }
+    }
+
+    @Test
+    public void testDimension() throws Exception {
+        final Events events = getEvents();
+        final String testDimensionKey = "test-dimension-key";
+        final double testDimensionValue = 123D;
+        final long startTimestampMillis = System.currentTimeMillis();
+        final int total = ThreadLocalRandom.current().nextInt(100, 1000);
+        logger.info("storing {} random events", total);
+        for (int i = 0; i < total; ++i) {
+            final Map<String, Double> dimensions = getRandomDimensions(5);
+            // only add a specific dimension key to half of the events to be stored
+            if ((i + 1) % 2 == 0) dimensions.put(testDimensionKey, testDimensionValue + i);
+            events.store(this.namespace, startTimestampMillis + i, getRandomMetadata(5), dimensions);
+        }
+        final List<Events.Event> eventsRetrieved = events.dimension(
+            this.namespace,
+            testDimensionKey,
+            startTimestampMillis,
+            startTimestampMillis + total,
+            Collections.emptyMap(),
+            Collections.singletonMap(testDimensionKey, ">=" + testDimensionValue)
+        );
+        assertEquals(eventsRetrieved.size(), total / 2);
+        for (final Events.Event e : eventsRetrieved) {
+            assertTrue(e.getTimestampMillis() >= startTimestampMillis && e.getTimestampMillis() <= startTimestampMillis + total);
+            assertEquals(e.getMetadata().size(), 0);
+            assertEquals(e.getDimensions().size(), 1);
+            assertTrue(e.getDimensions().get(testDimensionKey) >= testDimensionValue);
         }
     }
 

--- a/cantor-grpc-client/src/main/java/com/salesforce/cantor/grpc/EventsOnGrpc.java
+++ b/cantor-grpc-client/src/main/java/com/salesforce/cantor/grpc/EventsOnGrpc.java
@@ -174,7 +174,7 @@ public class EventsOnGrpc extends AbstractBaseGrpcClient<EventsServiceBlockingSt
         });
     }
 
-    private List<Event> getEventsFromProtos(List<EventProto> eventProtos) {
+    private List<Event> getEventsFromProtos(final List<EventProto> eventProtos) {
         final List<Event> events = new ArrayList<>();
         for (final EventProto proto : eventProtos) {
             final ByteString payloadByteString = proto.getPayload();

--- a/cantor-grpc-client/src/main/java/com/salesforce/cantor/grpc/EventsOnGrpc.java
+++ b/cantor-grpc-client/src/main/java/com/salesforce/cantor/grpc/EventsOnGrpc.java
@@ -100,21 +100,8 @@ public class EventsOnGrpc extends AbstractBaseGrpcClient<EventsServiceBlockingSt
                     .setAscending(ascending)
                     .setLimit(limit)
                     .build();
-            final List<Event> results = new ArrayList<>();
             final GetResponse response = getStub().get(request);
-            final List<EventProto> eventProtos = response.getResultsList();
-            for (final EventProto proto : eventProtos) {
-                final ByteString payloadByteString = proto.getPayload();
-                results.add(
-                        new Event(
-                                proto.getTimestampMillis(),
-                                proto.getMetadataMap(),
-                                proto.getDimensionsMap(),
-                                payloadByteString != null ? payloadByteString.toByteArray() : null
-                        )
-                );
-            }
-            return results;
+            return getEventsFromProtos(response.getResultsList());
         });
     }
 
@@ -147,6 +134,34 @@ public class EventsOnGrpc extends AbstractBaseGrpcClient<EventsServiceBlockingSt
     }
 
     @Override
+    public List<Event> dimension(final String namespace,
+                                 final String dimensionKey,
+                                 final long startTimestampMillis,
+                                 final long endTimestampMillis,
+                                 final Map<String, String> metadataQuery,
+                                 final Map<String, String> dimensionsQuery) throws IOException {
+        checkDimension(namespace,
+            dimensionKey,
+            startTimestampMillis,
+            endTimestampMillis,
+            metadataQuery,
+            dimensionsQuery
+        );
+        return call(() -> {
+            final DimensionRequest request = DimensionRequest.newBuilder()
+                    .setNamespace(namespace)
+                    .setDimensionKey(dimensionKey)
+                    .setStartTimestampMillis(startTimestampMillis)
+                    .setEndTimestampMillis(endTimestampMillis)
+                    .putAllMetadataQuery(nullToEmpty(metadataQuery))
+                    .putAllDimensionsQuery(nullToEmpty(dimensionsQuery))
+                    .build();
+            final DimensionResponse dimensionResponse = getStub().dimension(request);
+            return getEventsFromProtos(dimensionResponse.getValuesList());
+        });
+    }
+
+    @Override
     public void expire(final String namespace, final long endTimestampMillis) throws IOException {
         checkExpire(namespace, endTimestampMillis);
         call(() -> {
@@ -157,6 +172,22 @@ public class EventsOnGrpc extends AbstractBaseGrpcClient<EventsServiceBlockingSt
             getStub().expire(request);
             return null;
         });
+    }
+
+    private List<Event> getEventsFromProtos(List<EventProto> eventProtos) {
+        final List<Event> events = new ArrayList<>();
+        for (final EventProto proto : eventProtos) {
+            final ByteString payloadByteString = proto.getPayload();
+            events.add(
+                    new Event(
+                            proto.getTimestampMillis(),
+                            proto.getMetadataMap(),
+                            proto.getDimensionsMap(),
+                            payloadByteString != null ? payloadByteString.toByteArray() : null
+                    )
+            );
+        }
+        return events;
     }
 }
 

--- a/cantor-grpc-protos/src/main/proto/events.proto
+++ b/cantor-grpc-protos/src/main/proto/events.proto
@@ -68,6 +68,20 @@ message MetadataResponse {
     repeated string values = 1;
 }
 
+// events.dimension()
+message DimensionRequest {
+    string namespace = 1;
+    string dimension_key = 2;
+    uint64 start_timestamp_millis = 3;
+    uint64 end_timestamp_millis = 4;
+    map<string, string> metadata_query = 5;
+    map<string, string> dimensions_query = 6;
+}
+
+message DimensionResponse {
+    repeated EventProto values = 1;
+}
+
 // events.expire()
 message ExpireRequest {
     string namespace = 1;
@@ -81,6 +95,7 @@ service EventsService {
     rpc drop (DropRequest) returns (VoidResponse) {}
     rpc store (StoreRequest) returns (VoidResponse) {}
     rpc metadata (MetadataRequest) returns (MetadataResponse) {}
+    rpc dimension (DimensionRequest) returns (DimensionResponse) {}
     rpc expire (ExpireRequest) returns (VoidResponse) {}
 }
 

--- a/cantor-grpc-service/src/main/java/com/salesforce/cantor/grpc/EventsGrpcService.java
+++ b/cantor-grpc-service/src/main/java/com/salesforce/cantor/grpc/EventsGrpcService.java
@@ -186,7 +186,7 @@ public class EventsGrpcService extends EventsServiceGrpc.EventsServiceImplBase {
         return this.cantor.events();
     }
 
-    private List<EventProto> getProtosFromEvents(List<Events.Event> events) {
+    private List<EventProto> getProtosFromEvents(final List<Events.Event> events) {
         final List<EventProto> eventProtos = new ArrayList<>();
         for (final Events.Event event : events) {
             eventProtos.add(EventProto.newBuilder()

--- a/cantor-grpc-service/src/main/java/com/salesforce/cantor/grpc/EventsGrpcService.java
+++ b/cantor-grpc-service/src/main/java/com/salesforce/cantor/grpc/EventsGrpcService.java
@@ -91,17 +91,7 @@ public class EventsGrpcService extends EventsServiceGrpc.EventsServiceImplBase {
                     request.getAscending(),
                     request.getLimit());
             if (!results.isEmpty()) {
-                final List<EventProto> eventProtos = new ArrayList<>(results.size());
-                for (final Events.Event event : results) {
-                    eventProtos.add(EventProto.newBuilder()
-                            .setTimestampMillis(event.getTimestampMillis())
-                            .putAllMetadata(event.getMetadata())
-                            .putAllDimensions(event.getDimensions())
-                            .setPayload(event.getPayload() != null ? ByteString.copyFrom(event.getPayload()) : ByteString.EMPTY)
-                            .build()
-                    );
-                }
-                responseBuilder.addAllResults(eventProtos);
+                responseBuilder.addAllResults(getProtosFromEvents(results));
             }
             sendResponse(responseObserver, responseBuilder.build());
         } catch (IOException e) {
@@ -154,6 +144,28 @@ public class EventsGrpcService extends EventsServiceGrpc.EventsServiceImplBase {
     }
 
     @Override
+    public void dimension(final DimensionRequest request, final StreamObserver<DimensionResponse> responseObserver) {
+        if (Context.current().isCancelled()) {
+            sendCancelledError(responseObserver, Context.current().cancellationCause());
+            return;
+        }
+        try {
+            final List<Events.Event> results = getEvents().dimension(
+                    request.getNamespace(),
+                    request.getDimensionKey(),
+                    request.getStartTimestampMillis(),
+                    request.getEndTimestampMillis(),
+                    request.getMetadataQueryMap(),
+                    request.getDimensionsQueryMap()
+            );
+            final DimensionResponse response = DimensionResponse.newBuilder().addAllValues(getProtosFromEvents(results)).build();
+            sendResponse(responseObserver, response);
+        } catch (IOException e) {
+            sendError(responseObserver, e);
+        }
+    }
+
+    @Override
     public void expire(final ExpireRequest request, final StreamObserver<VoidResponse> responseObserver) {
         if (Context.current().isCancelled()) {
             sendCancelledError(responseObserver, Context.current().cancellationCause());
@@ -172,6 +184,20 @@ public class EventsGrpcService extends EventsServiceGrpc.EventsServiceImplBase {
 
     private Events getEvents() {
         return this.cantor.events();
+    }
+
+    private List<EventProto> getProtosFromEvents(List<Events.Event> events) {
+        final List<EventProto> eventProtos = new ArrayList<>();
+        for (final Events.Event event : events) {
+            eventProtos.add(EventProto.newBuilder()
+                    .setTimestampMillis(event.getTimestampMillis())
+                    .putAllMetadata(event.getMetadata())
+                    .putAllDimensions(event.getDimensions())
+                    .setPayload(event.getPayload() != null ? ByteString.copyFrom(event.getPayload()) : ByteString.EMPTY)
+                    .build()
+            );
+        }
+        return eventProtos;
     }
 }
 

--- a/cantor-http-service/src/main/java/com/salesforce/cantor/http/resources/EventsResource.java
+++ b/cantor-http-service/src/main/java/com/salesforce/cantor/http/resources/EventsResource.java
@@ -140,6 +140,33 @@ public class EventsResource {
         return Response.ok(parser.toJson(metadataValueSet)).build();
     }
 
+    @GET
+    @Path("/{namespace}/dimension/{dimension}")
+    @Produces(MediaType.APPLICATION_JSON)
+    @Operation(summary = "Get all events for a dimension")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200",
+                    description = "Provides all events (containing only the specified dimension) matching query parameters",
+                    content = @Content(array = @ArraySchema(schema = @Schema(implementation = Event.class)))),
+            @ApiResponse(responseCode = "400", description = "One of the query parameters has a bad value"),
+            @ApiResponse(responseCode = "500", description = serverErrorMessage)
+    })
+    public Response getDimension(@Parameter(description = "Namespace identifier") @PathParam("namespace") final String namespace,
+                                @Parameter(description = "Specific dimension to have") @PathParam("dimension") final String dimension,
+                                @BeanParam final EventsDataSourceBean bean) throws IOException {
+        logger.info("received request for dimension {} in namespace {}", dimension, namespace);
+        logger.debug("request parameters: {}", bean);
+        final List<Event> thinEvents = this.cantor.events().dimension(
+                namespace,
+                dimension,
+                bean.getStart(),
+                bean.getEnd(),
+                bean.getMetadataQuery(),
+                bean.getDimensionsquery()
+        );
+        return Response.ok(parser.toJson(thinEvents)).build();
+    }
+
     @PUT
     @Path("/{namespace}")
     @Operation(summary = "Create an event namespace")

--- a/cantor-http-service/src/main/java/com/salesforce/cantor/http/resources/EventsResource.java
+++ b/cantor-http-service/src/main/java/com/salesforce/cantor/http/resources/EventsResource.java
@@ -143,7 +143,7 @@ public class EventsResource {
     @GET
     @Path("/{namespace}/dimension/{dimension}")
     @Produces(MediaType.APPLICATION_JSON)
-    @Operation(summary = "Get all events for a dimension")
+    @Operation(summary = "Get all events with a dimension")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200",
                     description = "Provides all events (containing only the specified dimension) matching query parameters",

--- a/cantor-jdbc/src/main/java/com/salesforce/cantor/jdbc/AbstractBaseEventsOnJdbc.java
+++ b/cantor-jdbc/src/main/java/com/salesforce/cantor/jdbc/AbstractBaseEventsOnJdbc.java
@@ -101,6 +101,29 @@ public abstract class AbstractBaseEventsOnJdbc extends AbstractBaseCantorOnJdbc 
     }
 
     @Override
+    public List<Event> dimension(String namespace,
+                                 String dimensionKey,
+                                 long startTimestampMillis,
+                                 long endTimestampMillis,
+                                 Map<String, String> metadataQuery,
+                                 Map<String, String> dimensionsQuery) throws IOException {
+        checkDimension(namespace,
+            dimensionKey,
+            startTimestampMillis,
+            endTimestampMillis,
+            metadataQuery,
+            dimensionsQuery
+        );
+        return doDimension(namespace,
+            dimensionKey,
+            startTimestampMillis,
+            endTimestampMillis,
+            metadataQuery,
+            dimensionsQuery
+        );
+    }
+
+    @Override
     public void expire(final String namespace, final long endTimestampMillis) throws IOException {
         checkExpire(namespace, endTimestampMillis);
         doExpire(namespace, endTimestampMillis);
@@ -691,6 +714,15 @@ public abstract class AbstractBaseEventsOnJdbc extends AbstractBaseCantorOnJdbc 
             throw new IOException("events get operation timed out", e);
         }
         return results;
+    }
+
+    private List<Event> doDimension(final String namespace,
+                                    final String metadataKey,
+                                    final long startTimestampMillis,
+                                    final long endTimestampMillis,
+                                    final Map<String, String> metadataQuery,
+                                    final Map<String, String> dimensionsQuery) throws IOException {
+        return null;
     }
 
     // the metadata query object can contain these patterns:

--- a/cantor-jdbc/src/main/java/com/salesforce/cantor/jdbc/AbstractBaseEventsOnJdbc.java
+++ b/cantor-jdbc/src/main/java/com/salesforce/cantor/jdbc/AbstractBaseEventsOnJdbc.java
@@ -8,7 +8,6 @@
 package com.salesforce.cantor.jdbc;
 
 import com.salesforce.cantor.Events;
-import jdk.nashorn.internal.ir.annotations.Immutable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -109,18 +108,18 @@ public abstract class AbstractBaseEventsOnJdbc extends AbstractBaseCantorOnJdbc 
                                  Map<String, String> metadataQuery,
                                  Map<String, String> dimensionsQuery) throws IOException {
         checkDimension(namespace,
-            dimensionKey,
-            startTimestampMillis,
-            endTimestampMillis,
-            metadataQuery,
-            dimensionsQuery
+                dimensionKey,
+                startTimestampMillis,
+                endTimestampMillis,
+                metadataQuery,
+                dimensionsQuery
         );
         return doDimension(namespace,
-            dimensionKey,
-            startTimestampMillis,
-            endTimestampMillis,
-            metadataQuery,
-            dimensionsQuery
+                dimensionKey,
+                startTimestampMillis,
+                endTimestampMillis,
+                nullToEmpty(metadataQuery),
+                nullToEmpty(dimensionsQuery)
         );
     }
 
@@ -957,7 +956,7 @@ public abstract class AbstractBaseEventsOnJdbc extends AbstractBaseCantorOnJdbc 
 
     private long getWindowForTimestamp(final long timestampMillis) {
         return (timestampMillis / getWindowSizeMillis()) * getWindowSizeMillis();
-}
+    }
 
     private long getWindowSizeMillis() {
         return TimeUnit.DAYS.toMillis(1);  // one per day

--- a/cantor-jdbc/src/main/java/com/salesforce/cantor/jdbc/AbstractBaseEventsOnJdbc.java
+++ b/cantor-jdbc/src/main/java/com/salesforce/cantor/jdbc/AbstractBaseEventsOnJdbc.java
@@ -737,7 +737,7 @@ public abstract class AbstractBaseEventsOnJdbc extends AbstractBaseCantorOnJdbc 
         final ExecutorService executorService = Executors.newCachedThreadPool();
         final List<Event> results = new CopyOnWriteArrayList<>();
         for (String chunkTableName: chunkTables) {
-            final String sqlFormat = "SELECT %s %s FROM %s WHERE %s BETWEEN ? AND ? ";
+            final String sqlFormat = "SELECT %s, %s as DIMENSION_VALUE FROM %s WHERE %s BETWEEN ? AND ? ";
             final StringBuilder sqlBuilder = new StringBuilder(String.format(sqlFormat,
                     quote(getEventTimestampColumnName()),
                     quote(getDimensionKeyColumnName(dimensionKey)),
@@ -760,9 +760,9 @@ public abstract class AbstractBaseEventsOnJdbc extends AbstractBaseCantorOnJdbc 
                         addParameters(preparedStatement, parameters.toArray());
                         try (final ResultSet resultSet = preparedStatement.executeQuery()) {
                             while (resultSet.next()) {
-                                final Map<String, Double> dimension = Collections.singletonMap(dimensionKey, resultSet.getDouble(dimensionKey));
+                                final Map<String, Double> dimension = Collections.singletonMap(dimensionKey, resultSet.getDouble("DIMENSION_VALUE"));
                                 final long timestampMillis = resultSet.getLong(1);
-                                results.add(new Event(timestampMillis, null, dimension, null));
+                                results.add(new Event(timestampMillis, Collections.emptyMap(), dimension, null));
                             }
                         }
                     }

--- a/cantor-metrics/src/main/java/com/salesforce/cantor/metrics/MetricCollectingEvents.java
+++ b/cantor-metrics/src/main/java/com/salesforce/cantor/metrics/MetricCollectingEvents.java
@@ -75,6 +75,23 @@ public class MetricCollectingEvents extends BaseMetricCollectingCantor implement
     }
 
     @Override
+    public List<Event> dimension(final String namespace,
+                                 final String dimensionKey,
+                                 final long startTimestampMillis,
+                                 final long endTimestampMillis,
+                                 final Map<String, String> metadataQuery,
+                                 final Map<String, String> dimensionsQuery) throws IOException {
+        return metrics(() -> this.delegate
+                .dimension(namespace,
+                        dimensionKey,
+                        startTimestampMillis,
+                        endTimestampMillis,
+                        metadataQuery,
+                        dimensionsQuery
+                ), "dimension", namespace, super::size);
+    }
+
+    @Override
     public void expire(final String namespace, final long endTimestampMillis) throws IOException {
         metrics(() -> this.delegate.expire(namespace, endTimestampMillis), "expire", namespace);
     }

--- a/cantor-misc/src/main/java/com/salesforce/cantor/misc/archivable/impl/ArchivableEvents.java
+++ b/cantor-misc/src/main/java/com/salesforce/cantor/misc/archivable/impl/ArchivableEvents.java
@@ -70,19 +70,19 @@ public class ArchivableEvents extends AbstractBaseArchivableNamespaceable<Events
 
     @Override
     public List<Event> dimension(final String namespace,
-                                final String dimensionKey,
-                                final long startTimestampMillis,
-                                final long endTimestampMillis,
-                                final Map<String, String> metadataQuery,
-                                final Map<String, String> dimensionsQuery) throws IOException {
+                                 final String dimensionKey,
+                                 final long startTimestampMillis,
+                                 final long endTimestampMillis,
+                                 final Map<String, String> metadataQuery,
+                                 final Map<String, String> dimensionsQuery) throws IOException {
         getArchiver().restore(getDelegate(), namespace, startTimestampMillis, endTimestampMillis);
         return getDelegate().dimension(namespace,
-                dimensionKey,
-                startTimestampMillis,
-                endTimestampMillis,
-                metadataQuery,
-                dimensionsQuery
-        );
+                    dimensionKey,
+                    startTimestampMillis,
+                    endTimestampMillis,
+                    metadataQuery,
+                    dimensionsQuery
+            );
     }
 
     @Override

--- a/cantor-misc/src/main/java/com/salesforce/cantor/misc/archivable/impl/ArchivableEvents.java
+++ b/cantor-misc/src/main/java/com/salesforce/cantor/misc/archivable/impl/ArchivableEvents.java
@@ -69,6 +69,23 @@ public class ArchivableEvents extends AbstractBaseArchivableNamespaceable<Events
     }
 
     @Override
+    public List<Event> dimension(final String namespace,
+                                final String dimensionKey,
+                                final long startTimestampMillis,
+                                final long endTimestampMillis,
+                                final Map<String, String> metadataQuery,
+                                final Map<String, String> dimensionsQuery) throws IOException {
+        getArchiver().restore(getDelegate(), namespace, startTimestampMillis, endTimestampMillis);
+        return getDelegate().dimension(namespace,
+                dimensionKey,
+                startTimestampMillis,
+                endTimestampMillis,
+                metadataQuery,
+                dimensionsQuery
+        );
+    }
+
+    @Override
     public void expire(final String namespace, final long endTimestampMillis) throws IOException {
         // archiving all before deletion
         getArchiver().archive(getDelegate(), namespace, endTimestampMillis);

--- a/cantor-misc/src/main/java/com/salesforce/cantor/misc/async/AsyncEvents.java
+++ b/cantor-misc/src/main/java/com/salesforce/cantor/misc/async/AsyncEvents.java
@@ -90,11 +90,11 @@ public class AsyncEvents extends AbstractBaseAsyncNamespaceable<Events> implemen
 
     @Override
     public List<Event> dimension(final String namespace,
-                                final String dimensionKey,
-                                final long startTimestampMillis,
-                                final long endTimestampMillis,
-                                final Map<String, String> metadataQuery,
-                                final Map<String, String> dimensionsQuery) throws IOException {
+                                 final String dimensionKey,
+                                 final long startTimestampMillis,
+                                 final long endTimestampMillis,
+                                 final Map<String, String> metadataQuery,
+                                 final Map<String, String> dimensionsQuery) throws IOException {
         checkDimension(namespace, dimensionKey, startTimestampMillis, endTimestampMillis, metadataQuery, dimensionsQuery);
         return submitCall(() -> getDelegate()
                 .dimension(namespace,

--- a/cantor-misc/src/main/java/com/salesforce/cantor/misc/async/AsyncEvents.java
+++ b/cantor-misc/src/main/java/com/salesforce/cantor/misc/async/AsyncEvents.java
@@ -89,6 +89,25 @@ public class AsyncEvents extends AbstractBaseAsyncNamespaceable<Events> implemen
     }
 
     @Override
+    public List<Event> dimension(final String namespace,
+                                final String dimensionKey,
+                                final long startTimestampMillis,
+                                final long endTimestampMillis,
+                                final Map<String, String> metadataQuery,
+                                final Map<String, String> dimensionsQuery) throws IOException {
+        checkDimension(namespace, dimensionKey, startTimestampMillis, endTimestampMillis, metadataQuery, dimensionsQuery);
+        return submitCall(() -> getDelegate()
+                .dimension(namespace,
+                        dimensionKey,
+                        startTimestampMillis,
+                        endTimestampMillis,
+                        metadataQuery,
+                        dimensionsQuery
+                )
+        );
+    }
+
+    @Override
     public void expire(final String namespace, final long endTimestampMillis) throws IOException {
         checkExpire(namespace, endTimestampMillis);
         submitCall(() -> { getDelegate().expire(namespace, endTimestampMillis); return null; });

--- a/cantor-misc/src/main/java/com/salesforce/cantor/misc/loggable/LoggableEvents.java
+++ b/cantor-misc/src/main/java/com/salesforce/cantor/misc/loggable/LoggableEvents.java
@@ -77,6 +77,28 @@ public class LoggableEvents extends AbstractBaseLoggableNamespaceable<Events> im
     }
 
     @Override
+    public List<Event> dimension(final String namespace,
+                                 final String dimensionKey,
+                                 final long startTimestampMillis,
+                                 final long endTimestampMillis,
+                                 final Map<String, String> metadataQuery,
+                                 final Map<String, String> dimensionsQuery) throws IOException {
+        checkDimension(namespace, dimensionKey, startTimestampMillis, endTimestampMillis, metadataQuery, dimensionsQuery);
+        return logCall(() -> getDelegate()
+                        .dimension(namespace,
+                                dimensionKey,
+                                startTimestampMillis,
+                                endTimestampMillis,
+                                metadataQuery,
+                                dimensionsQuery
+                        ),
+                "dimension", namespace,
+                dimensionKey, startTimestampMillis, endTimestampMillis,
+                nullToEmpty(metadataQuery).keySet(), nullToEmpty(dimensionsQuery).keySet()
+        );
+    }
+
+    @Override
     public void expire(final String namespace, final long endTimestampMillis) throws IOException {
         checkExpire(namespace, endTimestampMillis);
         logCall(() -> { getDelegate().expire(namespace, endTimestampMillis); return null; },

--- a/cantor-misc/src/main/java/com/salesforce/cantor/misc/loggable/LoggableEvents.java
+++ b/cantor-misc/src/main/java/com/salesforce/cantor/misc/loggable/LoggableEvents.java
@@ -85,13 +85,13 @@ public class LoggableEvents extends AbstractBaseLoggableNamespaceable<Events> im
                                  final Map<String, String> dimensionsQuery) throws IOException {
         checkDimension(namespace, dimensionKey, startTimestampMillis, endTimestampMillis, metadataQuery, dimensionsQuery);
         return logCall(() -> getDelegate()
-                        .dimension(namespace,
-                                dimensionKey,
-                                startTimestampMillis,
-                                endTimestampMillis,
-                                metadataQuery,
-                                dimensionsQuery
-                        ),
+                .dimension(namespace,
+                        dimensionKey,
+                        startTimestampMillis,
+                        endTimestampMillis,
+                        metadataQuery,
+                        dimensionsQuery
+                ),
                 "dimension", namespace,
                 dimensionKey, startTimestampMillis, endTimestampMillis,
                 nullToEmpty(metadataQuery).keySet(), nullToEmpty(dimensionsQuery).keySet()

--- a/cantor-misc/src/main/java/com/salesforce/cantor/misc/rw/ReadWriteEvents.java
+++ b/cantor-misc/src/main/java/com/salesforce/cantor/misc/rw/ReadWriteEvents.java
@@ -56,6 +56,23 @@ public class ReadWriteEvents extends AbstractBaseReadWriteNamespaceable<Events> 
     }
 
     @Override
+    public List<Event> dimension(final String namespace,
+                                final String dimensionKey,
+                                final long startTimestampMillis,
+                                final long endTimestampMillis,
+                                final Map<String, String> metadataQuery,
+                                final Map<String, String> dimensionsQuery) throws IOException {
+        checkDimension(namespace, dimensionKey, startTimestampMillis, endTimestampMillis, metadataQuery, dimensionsQuery);
+        return getReadable().dimension(namespace,
+                dimensionKey,
+                startTimestampMillis,
+                endTimestampMillis,
+                metadataQuery,
+                dimensionsQuery
+        );
+    }
+
+    @Override
     public void expire(final String namespace, final long endTimestampMillis) throws IOException {
         checkExpire(namespace, endTimestampMillis);
         getWritable().expire(namespace, endTimestampMillis);

--- a/cantor-misc/src/main/java/com/salesforce/cantor/misc/rw/ReadWriteEvents.java
+++ b/cantor-misc/src/main/java/com/salesforce/cantor/misc/rw/ReadWriteEvents.java
@@ -57,11 +57,11 @@ public class ReadWriteEvents extends AbstractBaseReadWriteNamespaceable<Events> 
 
     @Override
     public List<Event> dimension(final String namespace,
-                                final String dimensionKey,
-                                final long startTimestampMillis,
-                                final long endTimestampMillis,
-                                final Map<String, String> metadataQuery,
-                                final Map<String, String> dimensionsQuery) throws IOException {
+                                 final String dimensionKey,
+                                 final long startTimestampMillis,
+                                 final long endTimestampMillis,
+                                 final Map<String, String> metadataQuery,
+                                 final Map<String, String> dimensionsQuery) throws IOException {
         checkDimension(namespace, dimensionKey, startTimestampMillis, endTimestampMillis, metadataQuery, dimensionsQuery);
         return getReadable().dimension(namespace,
                 dimensionKey,

--- a/cantor-misc/src/main/java/com/salesforce/cantor/misc/sharded/ShardedEvents.java
+++ b/cantor-misc/src/main/java/com/salesforce/cantor/misc/sharded/ShardedEvents.java
@@ -74,11 +74,11 @@ public class ShardedEvents extends AbstractBaseShardedNamespaceable<Events> impl
 
     @Override
     public List<Event> dimension(final String namespace,
-                                final String dimensionKey,
-                                final long startTimestampMillis,
-                                final long endTimestampMillis,
-                                final Map<String, String> metadataQuery,
-                                final Map<String, String> dimensionsQuery) throws IOException {
+                                 final String dimensionKey,
+                                 final long startTimestampMillis,
+                                 final long endTimestampMillis,
+                                 final Map<String, String> metadataQuery,
+                                 final Map<String, String> dimensionsQuery) throws IOException {
         checkDimension(namespace, dimensionKey, startTimestampMillis, endTimestampMillis, metadataQuery, dimensionsQuery);
         return getShard(namespace)
                 .dimension(namespace,

--- a/cantor-misc/src/main/java/com/salesforce/cantor/misc/sharded/ShardedEvents.java
+++ b/cantor-misc/src/main/java/com/salesforce/cantor/misc/sharded/ShardedEvents.java
@@ -73,6 +73,24 @@ public class ShardedEvents extends AbstractBaseShardedNamespaceable<Events> impl
     }
 
     @Override
+    public List<Event> dimension(final String namespace,
+                                final String dimensionKey,
+                                final long startTimestampMillis,
+                                final long endTimestampMillis,
+                                final Map<String, String> metadataQuery,
+                                final Map<String, String> dimensionsQuery) throws IOException {
+        checkDimension(namespace, dimensionKey, startTimestampMillis, endTimestampMillis, metadataQuery, dimensionsQuery);
+        return getShard(namespace)
+                .dimension(namespace,
+                        dimensionKey,
+                        startTimestampMillis,
+                        endTimestampMillis,
+                        metadataQuery,
+                        dimensionsQuery
+                );
+    }
+
+    @Override
     public void expire(final String namespace, final long endTimestampMillis) throws IOException {
         checkExpire(namespace, endTimestampMillis);
         getShard(namespace).expire(namespace, endTimestampMillis);


### PR DESCRIPTION
There is a use case for being able to extract only dimension values from events; very similar to what we have for metadata.

Here is the the function signature:
```
List<Event> dimension(String namespace, String dimensionKey, long startTimestampMillis, long endTimestampMillis, Map<String, String> metadataQuery, Map<String, String> dimensionsQuery) throws IOException;
```
Result is a list of events where each event only contains the specified dimension - no payload or metadata is included.