### PR TITLE
Replace Futures with ListenableFutures in Cantor

### DIFF
--- a/cantor-s3/src/main/java/com/salesforce/cantor/s3/EventsOnS3.java
+++ b/cantor-s3/src/main/java/com/salesforce/cantor/s3/EventsOnS3.java
@@ -52,13 +52,6 @@ public class EventsOnS3 extends AbstractBaseS3Namespaceable implements Events {
     private static final Logger siftingLogger = initSiftingLogger();
     private static final AtomicBoolean isInitialized = new AtomicBoolean(false);
 
-    private static final ScheduledExecutorService scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
-
-    // executor service to parallelize calls to s3
-    private static final ExecutorService executorService = Executors.newCachedThreadPool(
-            new ThreadFactoryBuilder().setNameFormat("cantor-s3-events-worker-%d").build()
-    );
-
     // cantor-events-<namespace>/<startTimestamp>-<endTimestamp>
     private static final String objectKeyPrefix = "cantor-events";
 
@@ -85,6 +78,23 @@ public class EventsOnS3 extends AbstractBaseS3Namespaceable implements Events {
     private final TransferManager s3TransferManager;
 
     private final String bufferDirectory;
+
+    private static class ExecutorFactory {
+        // return executor service to schedule buffer flushing at set time intervals
+        ScheduledExecutorService getScheduledExecutor() {
+            return Executors.newSingleThreadScheduledExecutor();
+        }
+
+        // return executor service to parallelize calls to s3, one for each Event interface method
+        ListeningExecutorService getListeningExecutor() {
+            return MoreExecutors.listeningDecorator(
+                Executors.newCachedThreadPool(
+                    new ThreadFactoryBuilder().setNameFormat("cantor-s3-events-worker-%d").build()
+                )
+            );
+        }
+    }
+    private static final ExecutorFactory executorFactory = new ExecutorFactory();
 
     public EventsOnS3(final AmazonS3 s3Client,
                       final String bucketName) throws IOException {
@@ -116,7 +126,7 @@ public class EventsOnS3 extends AbstractBaseS3Namespaceable implements Events {
         // schedule flush cycle to start immediately
         if (!isInitialized.getAndSet(true)) {
             rollover();
-            scheduledExecutor.scheduleAtFixedRate(this::flush, 0, flushIntervalSeconds, TimeUnit.SECONDS);
+            executorFactory.getScheduledExecutor().scheduleAtFixedRate(this::flush, 0, flushIntervalSeconds, TimeUnit.SECONDS);
         }
     }
 
@@ -152,7 +162,7 @@ public class EventsOnS3 extends AbstractBaseS3Namespaceable implements Events {
                          includePayloads,
                          ascending,
                          limit);
-        } catch (final AmazonS3Exception e) {
+        } catch (final AmazonS3Exception | InterruptedException e) {
             logger.warn("exception getting events from namespace: " + namespace, e);
             throw new IOException("exception getting events from namespace: " + namespace, e);
         }
@@ -174,7 +184,7 @@ public class EventsOnS3 extends AbstractBaseS3Namespaceable implements Events {
                     endTimestampMillis,
                     (metadataQuery != null) ? metadataQuery : Collections.emptyMap(),
                     (dimensionsQuery != null) ? dimensionsQuery : Collections.emptyMap());
-        } catch (final AmazonS3Exception e) {
+        } catch (final AmazonS3Exception | InterruptedException e) {
             logger.warn("exception getting metadata from namespace: " + namespace, e);
             throw new IOException("exception getting metadata from namespace: " + namespace, e);
         }
@@ -196,7 +206,7 @@ public class EventsOnS3 extends AbstractBaseS3Namespaceable implements Events {
                     endTimestampMillis,
                     (metadataQuery != null) ? metadataQuery : Collections.emptyMap(),
                     (dimensionsQuery != null) ? dimensionsQuery : Collections.emptyMap());
-        } catch (final AmazonS3Exception e) {
+        } catch (final AmazonS3Exception | InterruptedException e) {
             logger.warn("exception getting dimension from namespace: " + namespace, e);
             throw new IOException("exception getting dimension from namespace: " + namespace, e);
         }
@@ -208,7 +218,7 @@ public class EventsOnS3 extends AbstractBaseS3Namespaceable implements Events {
         checkNamespace(namespace);
         try {
             doExpire(namespace, endTimestampMillis);
-        } catch (final AmazonS3Exception e) {
+        } catch (final AmazonS3Exception | InterruptedException e) {
             logger.warn("exception expiring events from namespace: " + namespace, e);
             throw new IOException("exception expiring events from namespace: " + namespace, e);
         }
@@ -316,11 +326,12 @@ public class EventsOnS3 extends AbstractBaseS3Namespaceable implements Events {
                               final Map<String, String> dimensionsQuery,
                               final boolean includePayloads,
                               final boolean ascending,
-                              final int limit) throws IOException {
+                              final int limit) throws IOException, InterruptedException {
 
         final List<Event> results = new CopyOnWriteArrayList<>();
         // parallel calls to s3
-        final ListeningExecutorService service = MoreExecutors.listeningDecorator(executorService);
+        final ListeningExecutorService executorService = executorFactory.getListeningExecutor();
+        final AtomicBoolean futureHasFailed = new AtomicBoolean(false);
 
         // iterate over all s3 objects that match this request
         for (final String objectKey : getMatchingKeys(namespace, startTimestampMillis, endTimestampMillis)) {
@@ -328,23 +339,27 @@ public class EventsOnS3 extends AbstractBaseS3Namespaceable implements Events {
             if (!objectKey.endsWith("json")) {
                 continue;
             }
-            Futures.addCallback(
-                service.submit(() -> doCacheableGetOnObject(
-                    objectKey, startTimestampMillis, endTimestampMillis,
-                    metadataQuery, dimensionsQuery, includePayloads
-                )),
-                new FutureCallback<List<Event>>() {
-                    // we want this handler to run immediately after we push the big red button!
-                    public void onSuccess(List<Event> events) {
-                        results.addAll(events);
-                    }
-                    public void onFailure(Throwable e) {
-                        logger.warn("exception on get call to s3", e);
-                    }
-                },
-                service
+            ListenableFuture<List<Event>> future = executorService.submit(
+                () -> doCacheableGetOnObject(objectKey, startTimestampMillis, endTimestampMillis, metadataQuery,
+                    dimensionsQuery, includePayloads)
             );
+            FutureCallback<List<Event>> callback = new FutureCallback<List<Event>>() {
+                // we want this handler to run immediately after we push the big red button!
+                public void onSuccess(List<Event> events) {
+                    results.addAll(events);
+                }
+                public void onFailure(Throwable e) {
+                    futureHasFailed.set(true);
+                    logger.warn("exception on get call to s3", e);
+                }
+            };
+            Futures.addCallback(future, callback, MoreExecutors.directExecutor());
         }
+
+        executorService.shutdown();
+        executorService.awaitTermination(30, TimeUnit.SECONDS);
+
+        if (futureHasFailed.get()) throw new IOException("exception on get call to s3");
 
         // events are fetched from multiple sources, sort before returning
         sortEventsByTimestamp(results, ascending);
@@ -359,33 +374,39 @@ public class EventsOnS3 extends AbstractBaseS3Namespaceable implements Events {
                                    final long startTimestampMillis,
                                    final long endTimestampMillis,
                                    final Map<String, String> metadataQuery,
-                                   final Map<String, String> dimensionsQuery) throws IOException {
+                                   final Map<String, String> dimensionsQuery) throws IOException, InterruptedException {
 
         final Set<String> results = new CopyOnWriteArraySet<>();
         // parallel calls to s3
-        final ListeningExecutorService service = MoreExecutors.listeningDecorator(executorService);
+        final ListeningExecutorService executorService = executorFactory.getListeningExecutor();
+        final AtomicBoolean futureHasFailed = new AtomicBoolean(false);
+
         // iterate over all s3 objects that match this request
         for (final String objectKey : getMatchingKeys(namespace, startTimestampMillis, endTimestampMillis)) {
             // only query json files
             if (!objectKey.endsWith("json")) {
                 continue;
             }
-            Futures.addCallback(
-                service.submit(() -> doMetadataOnObject(
-                    objectKey, metadataKey, startTimestampMillis, endTimestampMillis,
+            ListenableFuture<Set<String>> future = executorService.submit(
+                () -> doMetadataOnObject(objectKey, metadataKey, startTimestampMillis, endTimestampMillis,
                     metadataQuery, dimensionsQuery)
-                ),
-                new FutureCallback<Set<String>>() {
-                    public void onSuccess(Set<String> metadata) {
-                        results.addAll(metadata);
-                    }
-                    public void onFailure(Throwable e) {
-                        logger.warn("exception on metadata call to s3", e);
-                    }
-                },
-                service
             );
+            FutureCallback<Set<String>> callback = new FutureCallback<Set<String>>() {
+                public void onSuccess(Set<String> metadata) {
+                    results.addAll(metadata);
+                }
+                public void onFailure(Throwable e) {
+                    futureHasFailed.set(true);
+                    logger.warn("exception on metadata call to s3", e);
+                }
+            };
+            Futures.addCallback(future, callback, MoreExecutors.directExecutor());
         }
+
+        executorService.shutdown();
+        executorService.awaitTermination(30, TimeUnit.SECONDS);
+
+        if (futureHasFailed.get()) throw new IOException("exception on metadata call to s3");
         return results;
     }
 
@@ -394,33 +415,38 @@ public class EventsOnS3 extends AbstractBaseS3Namespaceable implements Events {
                                     final long startTimestampMillis,
                                     final long endTimestampMillis,
                                     final Map<String, String> metadataQuery,
-                                    final Map<String, String> dimensionsQuery) throws IOException {
+                                    final Map<String, String> dimensionsQuery) throws IOException, InterruptedException {
         final List<Event> results = new CopyOnWriteArrayList<>();
         // parallel calls to s3
-        final ListeningExecutorService service = MoreExecutors.listeningDecorator(executorService);
+        final ListeningExecutorService executorService = executorFactory.getListeningExecutor();
+        final AtomicBoolean futureHasFailed = new AtomicBoolean(false);
+
         // iterate over all s3 objects that match this request
         for (final String objectKey : getMatchingKeys(namespace, startTimestampMillis, endTimestampMillis)) {
             // only query json files
             if (!objectKey.endsWith("json")) {
                 continue;
             }
-            Futures.addCallback(
-                service.submit(
-                    () -> doDimensionOnObject(
-                        objectKey, dimensionKey, startTimestampMillis, endTimestampMillis,
-                        metadataQuery, dimensionsQuery)
-                ),
-                new FutureCallback<List<Event>>() {
-                    public void onSuccess(List<Event> events) {
-                        results.addAll(events);
-                    }
-                    public void onFailure(Throwable e) {
-                        logger.warn("exception on dimension call to s3", e);
-                    }
-                },
-                service
+            ListenableFuture<List<Event>> future = executorService.submit(
+                () -> doDimensionOnObject(objectKey, dimensionKey, startTimestampMillis, endTimestampMillis,
+                    metadataQuery, dimensionsQuery)
             );
+            FutureCallback<List<Event>> callback = new FutureCallback<List<Event>>() {
+                public void onSuccess(List<Event> events) {
+                    results.addAll(events);
+                }
+                public void onFailure(Throwable e) {
+                    futureHasFailed.set(true);
+                    logger.warn("exception on dimension call to s3", e);
+                }
+            };
+            Futures.addCallback(future, callback, MoreExecutors.directExecutor());
         }
+
+        executorService.shutdown();
+        executorService.awaitTermination(30, TimeUnit.SECONDS);
+
+        if (futureHasFailed.get()) throw new IOException("exception on get call to s3");
         return results;
     }
 
@@ -527,7 +553,7 @@ public class EventsOnS3 extends AbstractBaseS3Namespaceable implements Events {
         return results;
     }
 
-    private void doExpire(final String namespace, final long endTimestampMillis) throws IOException {
+    private void doExpire(final String namespace, final long endTimestampMillis) throws IOException, InterruptedException {
         // TODO this has to be implemented properly
         logger.info("expiring namespace '{}' with end timestamp of '{}'", namespace, endTimestampMillis);
         final Set<String> keys = getMatchingKeys(namespace, 0, endTimestampMillis);
@@ -578,7 +604,7 @@ public class EventsOnS3 extends AbstractBaseS3Namespaceable implements Events {
     }
 
     private Set<String> getMatchingKeys(final String namespace, final long startTimestampMillis, final long endTimestampMillis)
-            throws IOException {
+            throws IOException, InterruptedException {
         final String cacheKey = String.format("%d-%d-%d", namespace.hashCode(), startTimestampMillis, endTimestampMillis);
         try {
             return keysCache.get(cacheKey, () -> doGetMatchingKeys(namespace, startTimestampMillis, endTimestampMillis));
@@ -587,7 +613,7 @@ public class EventsOnS3 extends AbstractBaseS3Namespaceable implements Events {
         }
     }
 
-    private Set<String> doGetMatchingKeys(final String namespace, final long startTimestampMillis, final long endTimestampMillis) {
+    private Set<String> doGetMatchingKeys(final String namespace, final long startTimestampMillis, final long endTimestampMillis) throws IOException, InterruptedException {
         final Set<String> prefixes = new HashSet<>();
         long start = startTimestampMillis;
         while (start <= endTimestampMillis) {
@@ -602,24 +628,31 @@ public class EventsOnS3 extends AbstractBaseS3Namespaceable implements Events {
             }
         }
         prefixes.add(String.format("%s/%s", getObjectKeyPrefix(namespace), directoryFormatterMin.format(endTimestampMillis)));
+
         final Set<String> matchingKeys = new ConcurrentSkipListSet<>();
-        final ListeningExecutorService service = MoreExecutors.listeningDecorator(executorService);
+        final ListeningExecutorService executorService = executorFactory.getListeningExecutor();
+        final AtomicBoolean futureHasFailed = new AtomicBoolean(false);
+
         for (final String prefix : prefixes) {
-            Futures.addCallback(
-                service.submit(
-                    () -> S3Utils.getKeys(this.s3Client, this.bucketName, prefix)
-                ),
-                new FutureCallback<Collection<String>>() {
-                    public void onSuccess(Collection<String> keys) {
-                        matchingKeys.addAll(keys);
-                    }
-                    public void onFailure(Throwable e) {
-                        logger.warn("exception on get call to s3", e);
-                    }
-                },
-                service
+            ListenableFuture<Collection<String>> future = executorService.submit(
+                () -> S3Utils.getKeys(this.s3Client, this.bucketName, prefix)
             );
+            FutureCallback<Collection<String>> callback = new FutureCallback<Collection<String>>() {
+                public void onSuccess(Collection<String> keys) {
+                    matchingKeys.addAll(keys);
+                }
+                public void onFailure(Throwable e) {
+                    futureHasFailed.set(true);
+                    logger.warn("exception on getting object keys from s3", e);
+                }
+            };
+            Futures.addCallback(future, callback, MoreExecutors.directExecutor());
         }
+
+        executorService.shutdown();
+        executorService.awaitTermination(30, TimeUnit.SECONDS);
+
+        if (futureHasFailed.get()) throw new IOException("exception on getting object keys from s3");
         return matchingKeys;
     }
 


### PR DESCRIPTION
- created a `ExectuorServiceFactory` class to provide a new `executorService` instance to every method, since before each method returns we need to shut down the related `executorService` instance, after which it can no longer accept new tasks to be submitted
- used an AtomicBoolean variable `futureHasFailed` to throw exceptions in case any of the futures have failed
- in the line `Futures.addCallback(future, callback, MoreExecutors.directExecutor())`, `directExecutor` is used so callback is executed on the same thread of the main method, instead of the `ListeningExecutorService`, which is shut down before some callbacks can be executed