### PR TITLE
Fix namespaces with json in name being overridden by this logic

### DIFF
--- a/cantor-s3/src/main/java/com/salesforce/cantor/s3/EventsOnS3.java
+++ b/cantor-s3/src/main/java/com/salesforce/cantor/s3/EventsOnS3.java
@@ -486,7 +486,7 @@ public class EventsOnS3 extends AbstractBaseS3Namespaceable implements Events {
                         && event.getDimensions().containsKey(dimensionKeyPayloadLength)) {
                     final long offset = event.getDimensions().get(dimensionKeyPayloadOffset).longValue();
                     final long length = event.getDimensions().get(dimensionKeyPayloadLength).longValue();
-                    final String payloadFilename = objectKey.replace("json", "b64");
+                    final String payloadFilename = objectKey.replace(".json", ".b64");
                     final byte[] payloadBase64Bytes = S3Utils.getObjectBytes(this.s3Client, this.bucketName, payloadFilename, offset, offset + length - 1);
                     if (payloadBase64Bytes == null || payloadBase64Bytes.length == 0) {
                         throw new IOException("failed to retrieve payload for event");


### PR DESCRIPTION
In the case that a namespace has `json` in the name this would change the namespace name in addition to the extension. With dot `.` being a reserved character which can't be part of a namespace name simply swapping `json` for `.json` should prevent this issue.