### PR TITLE
Allow config to enable endpoint override in awsClient

### DIFF
--- a/cantor-server/src/main/java/com/salesforce/cantor/server/Constants.java
+++ b/cantor-server/src/main/java/com/salesforce/cantor/server/Constants.java
@@ -38,5 +38,6 @@ public class Constants {
     public static final String CANTOR_S3_BUCKET_REGION = "region";
     public static final String CANTOR_S3_PROXY_HOST = "proxy.host";
     public static final String CANTOR_S3_PROXY_PORT = "proxy.port";
+    public static final String CANTOR_S3_ENDPOINT_OVERRIDE = "endpoint.override";
     public static final String CANTOR_S3_SETS_TYPE = "sets.type";
 }


### PR DESCRIPTION
- minor cleanup of clientConfiguration logic

In certain environments it's necessary to access the AWS SDK through the `AWS CodeBuild` which is a configuration in the client builder. I'm adding a field which if set to true will enable the fips CodeBuild endpoint. See this for reference: https://docs.aws.amazon.com/codebuild/latest/userguide/endpoint-specify.html