### PR TITLE
Exclude the namespace flag from all keys calls

### DIFF
--- a/cantor-s3/src/main/java/com/salesforce/cantor/s3/AbstractBaseS3Namespaceable.java
+++ b/cantor-s3/src/main/java/com/salesforce/cantor/s3/AbstractBaseS3Namespaceable.java
@@ -6,27 +6,24 @@ import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.HeadBucketRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.util.StringInputStream;
-import com.google.common.cache.*;
 import com.salesforce.cantor.Namespaceable;
-import com.salesforce.cantor.common.CommonPreconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.*;
-import java.nio.charset.StandardCharsets;
-import java.util.*;
-import java.util.concurrent.*;
-import java.util.stream.Collectors;
+import java.io.IOException;
+import java.io.InputStream;
 
 import static com.salesforce.cantor.common.CommonPreconditions.*;
 
 /**
  * A class responsible for managing namespace level calls for CantorOnS3
- *
+ * <p>
  * Note: there is a cache for the namespaces that refreshes every 30 seconds, however this means that there is a chance
  * an instance of Cantor may think that a namespace exists when it doesn't.
+ * </p>
  */
 public abstract class AbstractBaseS3Namespaceable implements Namespaceable {
+    protected static final String NAMESPACE_IDENTIFIER = ".namespace";
     private static final Logger logger = LoggerFactory.getLogger(AbstractBaseS3Namespaceable.class);
 
     protected final AmazonS3 s3Client;
@@ -75,7 +72,7 @@ public abstract class AbstractBaseS3Namespaceable implements Namespaceable {
 
     private void doCreate(final String namespace) throws IOException {
         logger.info("creating namespace: '{}'.'{}'", this.bucketName, namespace);
-        final String markerKey = getObjectKeyPrefix(namespace) + "/.namespace";
+        final String markerKey = getObjectKeyPrefix(namespace) + "/" + NAMESPACE_IDENTIFIER;
         if (S3Utils.doesObjectExist(this.s3Client, this.bucketName, markerKey)) {
             logger.info("namespace already exists: '{}'.'{}'", namespace, this.bucketName);
             return;

--- a/cantor-s3/src/main/java/com/salesforce/cantor/s3/ObjectsOnS3.java
+++ b/cantor-s3/src/main/java/com/salesforce/cantor/s3/ObjectsOnS3.java
@@ -13,7 +13,9 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Collection;
 import java.util.stream.Collectors;
 
@@ -158,6 +160,7 @@ public class ObjectsOnS3 extends AbstractBaseS3Namespaceable implements Streamin
         final String namespaceObjectPrefix = getObjectKey(namespace, prefix);
         return S3Utils.getKeys(this.s3Client, this.bucketName, namespaceObjectPrefix, start, count)
                 .stream()
+                .filter(key -> !key.endsWith(NAMESPACE_IDENTIFIER))
                 .map(objectFile -> objectFile.substring(namespaceObjectPrefix.length()))
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
Recently CantorOnS3 started adding an object with the name `.namespace` to every prefix on [create](https://github.com/salesforce/cantor/blob/master/cantor-s3/src/main/java/com/salesforce/cantor/s3/AbstractBaseS3Namespaceable.java#L78). An issue has popped up that when someone using the [ObjectsOnS3.keys](https://github.com/salesforce/cantor/blob/master/cantor-s3/src/main/java/com/salesforce/cantor/s3/ObjectsOnS3.java#L159) call that namespace object appears in the list. Some of these namespaces are format sensitive and are effectively broken as a result. Given this is an internal flag which has no need to be exposed to clients this PR aims to remove it from the results.

Quick and easy!