### PR TITLE
Patch the jackson-core 3pp vulnerability

### DIFF
--- a/cantor-http-server/pom.xml
+++ b/cantor-http-server/pom.xml
@@ -17,7 +17,7 @@
     <artifactId>cantor-http-server</artifactId>
 
     <properties>
-        <jersey.version>2.28</jersey.version>
+        <jersey.version>2.40</jersey.version>
         <groovy.version>3.0.8</groovy.version>
         <freemarker.version>2.3.30</freemarker.version>
     </properties>

--- a/cantor-http-server/pom.xml
+++ b/cantor-http-server/pom.xml
@@ -47,6 +47,12 @@
             <artifactId>cantor-mysql</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!--CANTOR GRPC-->
+        <dependency>
+            <groupId>com.salesforce.cantor</groupId>
+            <artifactId>cantor-grpc-client</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <!--CANTOR MISC-->
         <dependency>
             <groupId>com.salesforce.cantor</groupId>

--- a/cantor-http-server/src/main/java/com/salesforce/cantor/http/jersey/EmbeddedHttpServer.java
+++ b/cantor-http-server/src/main/java/com/salesforce/cantor/http/jersey/EmbeddedHttpServer.java
@@ -8,6 +8,7 @@
 package com.salesforce.cantor.http.jersey;
 
 import com.salesforce.cantor.Cantor;
+import com.salesforce.cantor.grpc.CantorOnGrpc;
 import com.salesforce.cantor.h2.CantorOnH2;
 import com.salesforce.cantor.h2.H2DataSourceProperties;
 import com.salesforce.cantor.h2.H2DataSourceProvider;
@@ -37,7 +38,7 @@ public class EmbeddedHttpServer {
         final ResourceConfig config = new SwaggerJaxrsConfig();
 
         // bind resources with required constructor parameters
-        final Cantor cantor = getCantorOnMysql();
+        final Cantor cantor = getCantorOnGrpc();
         config.register(new AbstractBinder() {
             @Override
             protected void configure() {
@@ -60,6 +61,11 @@ public class EmbeddedHttpServer {
         context.addServlet(DefaultServlet.class, "/");
 
         return server;
+    }
+
+    private Cantor getCantorOnGrpc() {
+        final Cantor cantorOnGrpc = new CantorOnGrpc("localhost:7443");
+        return new LoggableCantor(cantorOnGrpc);
     }
 
     private Cantor getCantorOnMysql() {

--- a/cantor-http-service/pom.xml
+++ b/cantor-http-service/pom.xml
@@ -17,7 +17,7 @@
     <artifactId>cantor-http-service</artifactId>
 
     <properties>
-        <spring.jersey.version>2.6.1</spring.jersey.version>
+        <spring.jersey.version>2.7.13</spring.jersey.version>
         <swagger.version>2.1.11</swagger.version>
         <swagger.classgraph.version>4.8.131</swagger.classgraph.version>
     </properties>

--- a/cantor-s3/pom.xml
+++ b/cantor-s3/pom.xml
@@ -25,9 +25,8 @@
     </parent>
 
     <properties>
-        <s3-sdk.version>1.12.261</s3-sdk.version>
+        <s3-sdk.version>1.12.501</s3-sdk.version>
         <mockito.version>2.21.0</mockito.version>
-        <jackson.version>2.14.1</jackson.version>
         <s3mock.version>2.1.28</s3mock.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
         <gson.version>2.9.0</gson.version>
         <grpc.version>1.44.0</grpc.version>
         <guava.version>31.0.1-jre</guava.version>
+        <jackson.version>2.15.2</jackson.version>
 
         <testng.version>7.0.0</testng.version>
 
@@ -195,6 +196,11 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.testng</groupId>


### PR DESCRIPTION
Upgrades all dependencies with a transitive dependency on jackson-core. `jackson-core` has been added to dependency management to ensure all transitives are updated.

This also adds support for grpc clients on the example cantor-http-server as I used it to validate jackson was working properly.