### PR TITLE
Patch h2database version

### DIFF
--- a/cantor-h2/pom.xml
+++ b/cantor-h2/pom.xml
@@ -25,7 +25,7 @@
     </parent>
 
     <properties>
-        <h2.version>2.1.210</h2.version>
+        <h2.version>2.2.220</h2.version>
     </properties>
 
     <dependencies>

--- a/cantor-h2/src/main/java/com/salesforce/cantor/h2/H2DataSourceProvider.java
+++ b/cantor-h2/src/main/java/com/salesforce/cantor/h2/H2DataSourceProvider.java
@@ -38,7 +38,6 @@ public class H2DataSourceProvider {
                         "MODE=MYSQL;" +
                         "COMPRESS=" + String.valueOf(datasourceProperties.isCompressed()).toUpperCase() + ";" +
                         "LOCK_TIMEOUT=30000;" +
-                        "DB_CLOSE_ON_EXIT=FALSE;" +
                         "TRACE_LEVEL_FILE=1;" +
                         "TRACE_MAX_FILE_SIZE=4;" +
                         "AUTOCOMMIT=TRUE;" +


### PR DESCRIPTION
- a fix has finally been released for h2! Long time coming!
- `DB_CLOSE_ON_EXIT` is not longer supported with `AUTO_SERVER`, so I'm removing it

We really should look into the optimal settings for an H2 server, but didn't want to make too many changes for this.