### PR TITLE
Add debug log line to Cantor around S3 Select

### DIFF
--- a/cantor-s3/src/main/java/com/salesforce/cantor/s3/S3Utils.java
+++ b/cantor-s3/src/main/java/com/salesforce/cantor/s3/S3Utils.java
@@ -295,8 +295,11 @@ public class S3Utils {
                 }
                 return results.toString();
             } finally {
+                final long timeSpent = (System.nanoTime() - before) / 1_000_000;
+                logger.debug("s3 select query: bucket={} key={} type={} expression={}; time spent: {}ms",
+                        request.getBucketName(), request.getKey(), request.getExpressionType(), request.getExpression(), timeSpent);
                 logger.info("query object - bucket: {} - key: {}; time spent: {}ms",
-                        request.getBucketName(), request.getKey(), ((System.nanoTime() - before) / 1_000_000)
+                        request.getBucketName(), request.getKey(), timeSpent
                 );
             }
         }


### PR DESCRIPTION
We ran into a small issue awhile back which turned out to be a malformed s3 select query. This debug log line should help us with issue like that in the future.

New log line only when in debug mode:
```
2024-07-09 12:05:23 DEBUG [cantor-events-s3-get-0] c.s.c.s.S3Utils [S3Utils.java:299] s3 select query: bucket=<bucket> key=cantor-events/test-3556498/1970/01/01/00/00.2024-07-09_19-03-09.e4f21b7223394c37977cccfac4d54d7e.json type=SQL expression=SELECT * FROM s3object[*] s WHERE s.timestampMillis >= 0 AND s.timestampMillis <= 0  AND s.metadata."test" LIKE 'test%' ; time spent: 202ms
```