### PR TITLE
Update java-grpc dependencies to the latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <jul.to.slf4j.version>1.7.32</jul.to.slf4j.version>
         <logback.version>1.2.13</logback.version>
         <gson.version>2.9.0</gson.version>
-        <grpc.version>1.54.1</grpc.version>
+        <grpc.version>1.68.0</grpc.version>
         <guava.version>32.0.0-jre</guava.version>
         <jackson.version>2.15.2</jackson.version>
 


### PR DESCRIPTION
- This patches the netty 3PP vulnerabilities

This still includes the transitive protobuf-java 3pp issue, so that will need to be dependency managed by consumer clients. I validated that using this newer grpc version is compatible with our current clients if they're on Cantor version `0.5.12`.