### PR TITLE
Bump GRPC version to latest to address security vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <jul.to.slf4j.version>1.7.32</jul.to.slf4j.version>
         <logback.version>1.2.13</logback.version>
         <gson.version>2.9.0</gson.version>
-        <grpc.version>1.68.0</grpc.version>
+        <grpc.version>1.71.0</grpc.version>
         <guava.version>32.0.0-jre</guava.version>
         <jackson.version>2.15.2</jackson.version>
 


### PR DESCRIPTION
Bump grpc version (grpc-netty, grpc-protos, grpc-stub) from 1.68.0 to 1.71.0 to address security vulnerabilities in netty version 4.1.52.Final. 