### PR TITLE
Upgrade 3pp dependencies to address security vulnerabilities

### DIFF
--- a/cantor-base/pom.xml
+++ b/cantor-base/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.salesforce.cantor</groupId>
         <artifactId>cantor-parent</artifactId>
-        <version>0.5.23</version>
+        <version>0.5.23-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cantor-common/pom.xml
+++ b/cantor-common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.salesforce.cantor</groupId>
         <artifactId>cantor-parent</artifactId>
-        <version>0.5.23</version>
+        <version>0.5.23-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cantor-functions/pom.xml
+++ b/cantor-functions/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>cantor-parent</artifactId>
         <groupId>com.salesforce.cantor</groupId>
-        <version>0.5.23</version>
+        <version>0.5.23-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>cantor-functions</artifactId>

--- a/cantor-grpc-client/pom.xml
+++ b/cantor-grpc-client/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.salesforce.cantor</groupId>
         <artifactId>cantor-parent</artifactId>
-        <version>0.5.23</version>
+        <version>0.5.23-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cantor-grpc-protos/pom.xml
+++ b/cantor-grpc-protos/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.salesforce.cantor</groupId>
         <artifactId>cantor-parent</artifactId>
-        <version>0.5.23</version>
+        <version>0.5.23-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cantor-grpc-protos/pom.xml
+++ b/cantor-grpc-protos/pom.xml
@@ -88,7 +88,7 @@
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <version>0.6.1</version>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.25.1:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
                     <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
                 </configuration>

--- a/cantor-grpc-service/pom.xml
+++ b/cantor-grpc-service/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.salesforce.cantor</groupId>
         <artifactId>cantor-parent</artifactId>
-        <version>0.5.23</version>
+        <version>0.5.23-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cantor-h2/pom.xml
+++ b/cantor-h2/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.salesforce.cantor</groupId>
         <artifactId>cantor-parent</artifactId>
-        <version>0.5.23</version>
+        <version>0.5.23-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cantor-http-server/pom.xml
+++ b/cantor-http-server/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>cantor-parent</artifactId>
         <groupId>com.salesforce.cantor</groupId>
-        <version>0.5.23</version>
+        <version>0.5.23-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -18,8 +18,8 @@
     <name>cantor-http-server</name>
 
     <properties>
-        <jersey.version>4.0.0</jersey.version>
-        <jetty.version>12.1.5</jetty.version>
+        <jersey.version>4.0.2</jersey.version>
+        <jetty.version>12.1.9</jetty.version>
         <groovy.version>3.0.8</groovy.version>
         <freemarker.version>2.3.30</freemarker.version>
     </properties>

--- a/cantor-http-service/pom.xml
+++ b/cantor-http-service/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>cantor-parent</artifactId>
         <groupId>com.salesforce.cantor</groupId>
-        <version>0.5.23</version>
+        <version>0.5.23-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/cantor-jdbc/pom.xml
+++ b/cantor-jdbc/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.salesforce.cantor</groupId>
         <artifactId>cantor-parent</artifactId>
-        <version>0.5.23</version>
+        <version>0.5.23-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cantor-metrics/pom.xml
+++ b/cantor-metrics/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.salesforce.cantor</groupId>
         <artifactId>cantor-parent</artifactId>
-        <version>0.5.23</version>
+        <version>0.5.23-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cantor-misc/pom.xml
+++ b/cantor-misc/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.salesforce.cantor</groupId>
         <artifactId>cantor-parent</artifactId>
-        <version>0.5.23</version>
+        <version>0.5.23-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cantor-mysql/pom.xml
+++ b/cantor-mysql/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.salesforce.cantor</groupId>
         <artifactId>cantor-parent</artifactId>
-        <version>0.5.23</version>
+        <version>0.5.23-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cantor-s3/pom.xml
+++ b/cantor-s3/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.salesforce.cantor</groupId>
         <artifactId>cantor-parent</artifactId>
-        <version>0.5.23</version>
+        <version>0.5.23-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/cantor-server/pom.xml
+++ b/cantor-server/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <artifactId>cantor-parent</artifactId>
         <groupId>com.salesforce.cantor</groupId>
-        <version>0.5.23</version>
+        <version>0.5.23-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,8 @@
         <gson.version>2.9.0</gson.version>
         <grpc.version>1.81.0</grpc.version>
         <netty.version>4.1.133.Final</netty.version>
-        <guava.version>32.0.0-jre</guava.version>
-        <jackson.version>2.15.2</jackson.version>
+        <guava.version>32.0.1-jre</guava.version>
+        <jackson.version>2.18.6</jackson.version>
 
         <testng.version>7.5.1</testng.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <logback.version>1.5.32</logback.version>
         <gson.version>2.9.0</gson.version>
         <grpc.version>1.81.0</grpc.version>
+        <protobuf.version>3.25.8</protobuf.version>
         <netty.version>4.1.133.Final</netty.version>
         <guava.version>32.0.1-jre</guava.version>
         <jackson.version>2.18.6</jackson.version>
@@ -135,6 +136,12 @@
                 <version>${netty.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <!--PROTOBUF-->
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+                <version>${protobuf.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.salesforce.cantor</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <artifactId>cantor-parent</artifactId>
     <packaging>pom</packaging>
     <name>cantor-parent</name>
-    <version>0.5.23</version>
+    <version>0.5.23-SNAPSHOT</version>
     <url>https://github.com/salesforce/cantor</url>
 
     <description>Generic DAO Layer</description>
@@ -28,11 +28,11 @@
         <target.version>1.8</target.version>
 
         <!--VERSIONS-->
-        <slf4j.version>1.7.32</slf4j.version>
-        <jul.to.slf4j.version>1.7.32</jul.to.slf4j.version>
-        <logback.version>1.2.13</logback.version>
+        <slf4j.version>2.0.17</slf4j.version>
+        <logback.version>1.5.32</logback.version>
         <gson.version>2.9.0</gson.version>
-        <grpc.version>1.71.0</grpc.version>
+        <grpc.version>1.81.0</grpc.version>
+        <netty.version>4.1.133.Final</netty.version>
         <guava.version>32.0.0-jre</guava.version>
         <jackson.version>2.15.2</jackson.version>
 
@@ -128,6 +128,14 @@
 
     <dependencyManagement>
         <dependencies>
+            <!--NETTY BOM-->
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-bom</artifactId>
+                <version>${netty.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>com.salesforce.cantor</groupId>
                 <artifactId>cantor-base</artifactId>
@@ -186,7 +194,7 @@
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>jul-to-slf4j</artifactId>
-                <version>${jul.to.slf4j.version}</version>
+                <version>${slf4j.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>


### PR DESCRIPTION
## Summary

  Upgrade third-party dependencies to address known security vulnerabilities.

  | Library | Old Version | New Version | CVE |
  |---------|-------------|-------------|-----|
  | Logback | 1.2.13 | 1.5.32 | CVE-2023-6378 |
  | SLF4J | 1.7.32 | 2.0.17 | (required by logback 1.5.x) |
  | gRPC | 1.71.0 | 1.81.0 | CVE-2025-24528 |
  | Netty BOM | — | 4.1.133.Final | CVE-2025-24970 |
  | Jetty | 12.1.5 | 12.1.9 | CVE-2025-2912 |
  | Jersey | 4.0.0 | 4.0.2 | — |
  | Guava | 32.0.0-jre | 32.0.1-jre | CVE-2023-2976 |
  | Jackson | 2.15.2 | 2.18.6 | WS-2026-0003 |
  | protobuf-java | 3.25.1 (transitive) | 3.25.8 (pinned) | CVE-2024-7254 |

  Additional cleanup:
  - Consolidated `jul.to.slf4j.version` into `slf4j.version` (same release artifact)
  - Added `protobuf-java` to `<dependencyManagement>` to override vulnerable transitive
  - Aligned `protoc` compiler version with runtime via `${protobuf.version}`

  ## Test plan

  - [x] Full `mvn clean install` with a local mysql running passes
  - [x] CI green