### PR TITLE
feat(cantor-multicloudj): add multi-cloud object storage module via multicloudj

### DIFF
--- a/cantor-multicloudj/README.md
+++ b/cantor-multicloudj/README.md
@@ -1,0 +1,85 @@
+# cantor-multicloudj
+
+Cantor on top of MultiCloudJ — cloud-agnostic object storage for AWS S3, GCP Cloud Storage, Alibaba OSS.
+
+## Maven Coordinates
+
+```xml
+<dependency>
+    <groupId>com.salesforce.cantor</groupId>
+    <artifactId>cantor-multicloudj</artifactId>
+    <version>0.5.25-SNAPSHOT</version>
+</dependency>
+```
+
+## Provider Runtime
+
+You must add exactly one provider runtime to your classpath:
+
+| Cloud Provider | Artifact |
+|---|---|
+| AWS S3 | `com.salesforce.multicloudj:blob-aws:0.4.0` |
+| GCP Cloud Storage | `com.salesforce.multicloudj:blob-gcp:0.4.0` |
+| Alibaba OSS | `com.salesforce.multicloudj:blob-ali:0.4.0` |
+
+For test/dev use only: `com.salesforce.multicloudj:blob-inmemory:0.4.0` provides an in-memory backend that requires no cloud credentials.
+
+## Java Version Requirement
+
+**Java 11+ required at runtime.** MultiCloudJ requires Java 11. The rest of Cantor targets Java 8; this module overrides source/target to 11 in its own POM. Consumers must run on JDK 11 or later.
+
+## Quick Start (AWS)
+
+```java
+BucketClient bc = BucketClient.builder("aws")
+        .withRegion("us-west-2")
+        .withBucket("my-bucket")
+        .build();
+try (CantorOnMulticloudj cantor = new CantorOnMulticloudj(bc)) {
+    cantor.objects().create("orders");
+    cantor.objects().store("orders", "k1", "hello".getBytes(UTF_8));
+}
+```
+
+## Advanced Configuration
+
+For credentials override, retry config, endpoint override, parallel upload settings, or tracing policy, use `BucketClient.builder(...)` directly and pass the resulting `BucketClient` to `new CantorOnMulticloudj(bucketClient)`. This module does NOT re-expose every builder option — refer to the [MultiCloudJ documentation](https://github.com/salesforce/multicloudj) for the full builder API.
+
+## Sets
+
+`Sets` are explicitly **unsupported** (matches `cantor-s3`). Calling `cantor.sets()` throws `UnsupportedOperationException`.
+
+## Azure
+
+Azure is **not supported**. MultiCloudJ 0.4.0 ships AWS, GCP, and Alibaba adapters only. No Azure adapter exists upstream as of June 2026.
+
+## Known Limitations / Trade-offs
+
+> **Performance-sensitive consumers must read this section before adopting `cantor-multicloudj`.**
+
+1. **No S3 Select equivalent — `EventsOnMulticloudj` uses client-side filtering.**
+   `EventsOnS3` pushes metadata/dimension predicates to S3 via S3 Select; the server returns only matching rows, and only the matching bytes traverse the network. MultiCloudJ 0.4.0 exposes no equivalent server-side query API. `EventsOnMulticloudj` therefore:
+   1. lists matching time-prefix blobs,
+   2. downloads each `.json` blob **in full**,
+   3. parses every line with Gson,
+   4. applies metadata/dimension predicates in-process.
+
+   This is correct but slower than `EventsOnS3` and incurs higher network egress proportional to the unfiltered event volume. For a 1 GB-per-namespace-per-day workload the difference is negligible; for 100 GB+ workloads with selective predicates it can be significant — acceptable for v1; performance-sensitive consumers should profile before adopting. **Future work:** evaluate columnar/Parquet event storage, an external secondary index (e.g., manifest blobs per namespace/time-window with materialized metadata), or push for a `query`/`scan` API in MultiCloudJ.
+
+2. **Java 11+ runtime.** MultiCloudJ requires Java 11. The rest of Cantor targets Java 8. `cantor-multicloudj` overrides source/target to 11 in its own pom; consumers must run on Java 11+.
+
+3. **`Sets` unsupported.** `cantor.sets()` throws `UnsupportedOperationException` — same as `cantor-s3`. Out of scope for this module; would require a separate spec.
+
+4. **Azure not supported.** MultiCloudJ 0.4.0 ships AWS, GCP, and Alibaba adapters only. No Azure adapter exists upstream as of June 2026.
+
+5. **Provider runtime is opt-in.** `blob-aws` / `blob-gcp` / `blob-ali` are declared `<optional>true</optional>`. Consumers must add the runtime they need to their own POM. The facade's convenience constructor surfaces a clear `IOException` if the runtime is missing.
+
+6. **Delete batch size capped at 100.** AWS supports 1000, GCP 100, Alibaba 1000. We use the floor for portability. Large drops/expires are paginated.
+
+7. **In-memory provider feature coverage.** `blob-inmemory` may not implement every method identically to real providers (notably range downloads). Tests are written defensively: where the in-memory provider diverges from a real provider, the test exercises the production fallback path and a Javadoc records the limitation.
+
+8. **`trim()` namespace collisions.** Namespace sanitisation uses `String.hashCode()` (32-bit). Collisions are theoretically findable at scale; inherited from `cantor-s3`'s design and kept for layout parity.
+
+9. **Aggregate javadoc / Java mixed-mode.** The parent POM aggregates javadoc with `source=${source.version}` (=1.8). `cantor-multicloudj`'s sources are Java 11. The module's per-module javadoc jar uses source=11 (correct); if running `mvn site` aggregates javadoc fails on Java-11 sources, the parent's aggregate javadoc execution must either bump to `source=11` (requires JDK 11 to build the site) or exclude this module. Out of scope for this spec; flagged for the maintainer who runs `mvn site` / `mvn release`.
+
+10. **Concurrent writes are serialised per-namespace.** Buffer writes are guarded by a `ReentrantLock` per namespace. Stores to different namespaces run in parallel; stores to the same namespace serialise. This matches `EventsOnS3` semantics.

--- a/cantor-multicloudj/pom.xml
+++ b/cantor-multicloudj/pom.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ Copyright (c) 2020, Salesforce.com, Inc.
+  ~ All rights reserved.
+  ~ SPDX-License-Identifier: BSD-3-Clause
+  ~ For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>cantor-multicloudj</artifactId>
+    <packaging>jar</packaging>
+    <name>cantor-multicloudj</name>
+    <description>Cantor on top of MultiCloudJ - cloud-agnostic object storage backend supporting AWS S3, GCP Cloud Storage, Alibaba OSS, and other MultiCloudJ providers.</description>
+
+    <parent>
+        <groupId>com.salesforce.cantor</groupId>
+        <artifactId>cantor-parent</artifactId>
+        <version>0.5.25-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <properties>
+        <multicloudj.version>0.4.0</multicloudj.version>
+        <!-- Override parent's Java 8 baseline: MultiCloudJ requires Java 11+ -->
+        <source.version>11</source.version>
+        <target.version>11</target.version>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <!-- CANTOR COMMON -->
+        <dependency>
+            <groupId>com.salesforce.cantor</groupId>
+            <artifactId>cantor-common</artifactId>
+        </dependency>
+
+        <!-- MULTICLOUDJ BLOB CLIENT -->
+        <dependency>
+            <groupId>com.salesforce.multicloudj</groupId>
+            <artifactId>blob-client</artifactId>
+            <version>${multicloudj.version}</version>
+        </dependency>
+
+        <!-- Provider runtimes: opt-in per consumer -->
+        <dependency>
+            <groupId>com.salesforce.multicloudj</groupId>
+            <artifactId>blob-aws</artifactId>
+            <version>${multicloudj.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.salesforce.multicloudj</groupId>
+            <artifactId>blob-gcp</artifactId>
+            <version>${multicloudj.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.salesforce.multicloudj</groupId>
+            <artifactId>blob-ali</artifactId>
+            <version>${multicloudj.version}</version>
+            <optional>true</optional>
+        </dependency>
+
+        <!-- LOGBACK -->
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+
+        <!-- JSON/GSON -->
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>${gson.version}</version>
+        </dependency>
+
+        <!-- GUAVA -->
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <!-- TEST SCOPE BELOW -->
+        <!-- TESTNG -->
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>${testng.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- CANTOR COMMON TEST JAR -->
+        <dependency>
+            <groupId>com.salesforce.cantor</groupId>
+            <artifactId>cantor-common</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <!-- MULTICLOUDJ IN-MEMORY PROVIDER -->
+        <dependency>
+            <groupId>com.salesforce.multicloudj</groupId>
+            <artifactId>blob-inmemory</artifactId>
+            <version>${multicloudj.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Re-declare the compiler config to lock source/target to 11
+                 even if the parent ever inlines its 1.8 default. Defense in depth. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${mvn.plugins.compiler.version}</version>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/cantor-multicloudj/src/main/java/com/salesforce/cantor/multicloudj/AbstractBaseMulticloudjNamespaceable.java
+++ b/cantor-multicloudj/src/main/java/com/salesforce/cantor/multicloudj/AbstractBaseMulticloudjNamespaceable.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2020, Salesforce.com, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.cantor.multicloudj;
+
+import com.salesforce.cantor.Namespaceable;
+import com.salesforce.multicloudj.blob.client.BucketClient;
+import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static com.salesforce.cantor.common.CommonPreconditions.*;
+
+public abstract class AbstractBaseMulticloudjNamespaceable implements Namespaceable {
+    protected static final String NAMESPACE_IDENTIFIER = ".namespace";
+    private static final Logger logger = LoggerFactory.getLogger(AbstractBaseMulticloudjNamespaceable.class);
+
+    protected final BucketClient bucketClient;
+    protected final String bucketName;
+
+    protected AbstractBaseMulticloudjNamespaceable(final BucketClient bucketClient, final String type) throws IOException {
+        checkArgument(bucketClient != null, "null bucket client");
+        this.bucketClient = bucketClient;
+        this.bucketName = bucketClient.getBucket();
+        try {
+            if (!this.bucketClient.doesBucketExist()) {
+                throw new IOException(String.format("bucket '%s' is not reachable", this.bucketName));
+            }
+        } catch (final SubstrateSdkException e) {
+            throw new IOException(String.format("bucket '%s' is not reachable", this.bucketName), e);
+        }
+    }
+
+    @Override
+    public void create(final String namespace) throws IOException {
+        checkCreate(namespace);
+        final String markerKey = getObjectKeyPrefix(namespace) + "/" + NAMESPACE_IDENTIFIER;
+        try {
+            if (MulticloudjUtils.doesObjectExist(this.bucketClient, markerKey)) {
+                logger.info("namespace already exists: '{}'.'{}'", namespace, this.bucketName);
+                return;
+            }
+            MulticloudjUtils.upload(this.bucketClient, markerKey,
+                    ("namespace=" + namespace).getBytes(StandardCharsets.UTF_8));
+        } catch (final SubstrateSdkException e) {
+            throw MulticloudjUtils.wrapAsIOException("create", namespace, e);
+        }
+    }
+
+    @Override
+    public void drop(final String namespace) throws IOException {
+        checkDrop(namespace);
+        try {
+            MulticloudjUtils.deleteAllUnderPrefix(this.bucketClient, getObjectKeyPrefix(namespace));
+        } catch (final SubstrateSdkException e) {
+            throw MulticloudjUtils.wrapAsIOException("drop", namespace, e);
+        }
+    }
+
+    protected abstract String getObjectKeyPrefix(final String namespace);
+
+    /**
+     * Verifies that {@code namespace} has been registered (i.e. its {@code .namespace}
+     * marker object is present in the bucket). Hoisted from {@code ObjectsOnMulticloudj}
+     * and {@code EventsOnMulticloudj} to keep namespace-existence semantics in one place.
+     */
+    protected void checkNamespaceExists(final String namespace) throws IOException {
+        final String markerKey = getObjectKeyPrefix(namespace) + "/" + NAMESPACE_IDENTIFIER;
+        if (!MulticloudjUtils.doesObjectExist(this.bucketClient, markerKey)) {
+            throw new IOException(String.format("namespace '%s' does not exist", namespace));
+        }
+    }
+
+    protected static String trim(final String namespace) {
+        final String cleanName = namespace.replaceAll("[^A-Za-z0-9_\\-/]", "").toLowerCase();
+        return String.format("%s-%s",
+                cleanName.substring(0, Math.min(64, cleanName.length())),
+                Math.abs(namespace.hashCode())
+        );
+    }
+}

--- a/cantor-multicloudj/src/main/java/com/salesforce/cantor/multicloudj/CantorOnMulticloudj.java
+++ b/cantor-multicloudj/src/main/java/com/salesforce/cantor/multicloudj/CantorOnMulticloudj.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2020, Salesforce.com, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.cantor.multicloudj;
+
+import com.salesforce.cantor.Cantor;
+import com.salesforce.cantor.Events;
+import com.salesforce.cantor.Objects;
+import com.salesforce.cantor.Sets;
+import com.salesforce.multicloudj.blob.client.BucketClient;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.salesforce.cantor.common.CommonPreconditions.*;
+
+public final class CantorOnMulticloudj implements Cantor, AutoCloseable {
+    private final BucketClient bucketClient;
+    private final boolean ownsClient;
+    private final ObjectsOnMulticloudj objects;
+    private final EventsOnMulticloudj events;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    public CantorOnMulticloudj(final BucketClient bucketClient) throws IOException {
+        checkArgument(bucketClient != null, "null bucket client");
+        this.bucketClient = bucketClient;
+        this.ownsClient = false;
+        this.objects = new ObjectsOnMulticloudj(bucketClient);
+        this.events = new EventsOnMulticloudj(bucketClient);
+    }
+
+    public CantorOnMulticloudj(final String providerId, final String region, final String bucket) throws IOException {
+        checkString(providerId, "invalid provider id");
+        checkString(region, "invalid region");
+        checkString(bucket, "invalid bucket");
+
+        BucketClient client;
+        try {
+            client = BucketClient.builder(providerId)
+                    .withRegion(region)
+                    .withBucket(bucket)
+                    .build();
+        } catch (RuntimeException e) {
+            throw new IOException(
+                    String.format("failed to construct BucketClient for provider '%s': ensure blob-%s dependency is on the runtime classpath",
+                            providerId, providerId), e);
+        }
+
+        this.bucketClient = client;
+        this.ownsClient = true;
+        this.objects = new ObjectsOnMulticloudj(client);
+        this.events = new EventsOnMulticloudj(client);
+    }
+
+    @Override
+    public Objects objects() {
+        return this.objects;
+    }
+
+    @Override
+    public Sets sets() {
+        throw new UnsupportedOperationException("Sets are not implemented on multicloudj");
+    }
+
+    @Override
+    public Events events() {
+        return this.events;
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (!closed.compareAndSet(false, true)) {
+            return;
+        }
+        events.close();
+        if (ownsClient) {
+            bucketClient.close();
+        }
+    }
+}

--- a/cantor-multicloudj/src/main/java/com/salesforce/cantor/multicloudj/EventsOnMulticloudj.java
+++ b/cantor-multicloudj/src/main/java/com/salesforce/cantor/multicloudj/EventsOnMulticloudj.java
@@ -1,0 +1,696 @@
+/*
+ * Copyright (c) 2020, Salesforce.com, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.cantor.multicloudj;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.salesforce.cantor.Events;
+import com.salesforce.multicloudj.blob.client.BucketClient;
+import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
+
+import static com.salesforce.cantor.common.CommonPreconditions.*;
+import static com.salesforce.cantor.common.EventsPreconditions.*;
+
+public final class EventsOnMulticloudj extends AbstractBaseMulticloudjNamespaceable
+        implements Events, AutoCloseable {
+
+    private static final Logger logger = LoggerFactory.getLogger(EventsOnMulticloudj.class);
+
+    static final String OBJECT_KEY_PREFIX = "cantor-events";
+    private static final long DEFAULT_FLUSH_SECONDS = 60;
+    private static final String DEFAULT_BUFFER_DIRECTORY = "cantor-events-multicloudj-buffer";
+    // DIRECTORY_FORMATTER_MIN_PATTERN is the canonical definition in MulticloudjUtils;
+    // re-exposed here as a package-private constant to avoid duplicate string literals.
+    static final String DIRECTORY_FORMATTER_MIN_PATTERN = MulticloudjUtils.DIRECTORY_FORMATTER_MIN_PATTERN;
+    private static final String CYCLE_NAME_FORMATTER_PATTERN = "yyyy-MM-dd_HH-mm-ss";
+    private static final String DIMENSION_KEY_PAYLOAD_OFFSET = ".cantor-payload-offset";
+    private static final String DIMENSION_KEY_PAYLOAD_LENGTH = ".cantor-payload-length";
+
+    private final String instanceId;
+    private final Path bufferRoot;
+    private final ScheduledExecutorService flushExecutor;
+    private final ExecutorService uploadPool;
+    private final Map<String, ReentrantLock> namespaceLocks = new ConcurrentHashMap<>();
+    private final LoadingCache<String, AtomicLong> payloadOffsets;
+    private final AtomicReference<String> currentFlushCycle;
+    private final Gson parser = new GsonBuilder().create();
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    public EventsOnMulticloudj(final BucketClient bucketClient) throws IOException {
+        this(bucketClient, DEFAULT_BUFFER_DIRECTORY, DEFAULT_FLUSH_SECONDS);
+    }
+
+    public EventsOnMulticloudj(final BucketClient bucketClient, final String bufferDirectory) throws IOException {
+        this(bucketClient, bufferDirectory, DEFAULT_FLUSH_SECONDS);
+    }
+
+    public EventsOnMulticloudj(final BucketClient bucketClient,
+                               final String bufferDirectory,
+                               final long flushIntervalSeconds) throws IOException {
+        super(bucketClient, "events");
+        checkArgument(flushIntervalSeconds > 0, "invalid flush interval");
+        checkString(bufferDirectory, "invalid buffer directory");
+
+        // F3 (CWE-22): validate + canonicalize the buffer directory path before use.
+        // Reject any input containing ".." segments to prevent path traversal, and refuse
+        // paths that resolve to an existing non-directory (e.g. a file or symlink target).
+        final Path validatedBufferRoot = validateAndCanonicalizeBufferDirectory(bufferDirectory);
+
+        this.instanceId = UUID.randomUUID().toString().replace("-", "");
+        this.bufferRoot = validatedBufferRoot.resolve(this.instanceId);
+
+        // F2 (CWE-276 / CWE-200): create the buffer directory with restrictive perms so
+        // buffered events (which may contain PII) are not world-readable on POSIX systems.
+        createBufferRootWithRestrictivePermissions(this.bufferRoot);
+
+        this.payloadOffsets = CacheBuilder.newBuilder()
+                .build(new CacheLoader<String, AtomicLong>() {
+                    @Override
+                    public AtomicLong load(final String ignoredPath) {
+                        return new AtomicLong(0);
+                    }
+                });
+
+        SimpleDateFormat cycleFormatter = new SimpleDateFormat(CYCLE_NAME_FORMATTER_PATTERN);
+        cycleFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+        this.currentFlushCycle = new AtomicReference<>(
+                cycleFormatter.format(new Date(System.currentTimeMillis())) + "." + this.instanceId
+        );
+
+        this.uploadPool = Executors.newFixedThreadPool(32, new ThreadFactory() {
+            private int count = 0;
+            @Override
+            public synchronized Thread newThread(Runnable r) {
+                Thread t = new Thread(r, "cantor-multicloudj-upload-" + instanceId.substring(0, 8) + "-" + count++);
+                t.setDaemon(true);
+                return t;
+            }
+        });
+
+        this.flushExecutor = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "cantor-multicloudj-flusher-" + instanceId.substring(0, 8));
+            t.setDaemon(true);
+            return t;
+        });
+        this.flushExecutor.scheduleWithFixedDelay(this::flush, flushIntervalSeconds, flushIntervalSeconds, TimeUnit.SECONDS);
+    }
+
+    @Override
+    public void store(final String namespace, final Collection<Event> batch) throws IOException {
+        checkStore(namespace, batch);
+        checkNamespaceExists(namespace);
+        try {
+            doStore(namespace, batch);
+        } catch (SubstrateSdkException e) {
+            throw MulticloudjUtils.wrapAsIOException("store", namespace, e);
+        }
+    }
+
+    @Override
+    public List<Event> get(final String namespace,
+                           final long startTimestampMillis,
+                           final long endTimestampMillis,
+                           final Map<String, String> metadataQuery,
+                           final Map<String, String> dimensionsQuery,
+                           final boolean includePayloads,
+                           final boolean ascending,
+                           final int limit) throws IOException {
+        checkGet(namespace, startTimestampMillis, endTimestampMillis, metadataQuery, dimensionsQuery);
+        checkNamespaceExists(namespace);
+        flushBeforeRead();
+        try {
+            return doGet(namespace, startTimestampMillis, endTimestampMillis,
+                    metadataQuery != null ? metadataQuery : Collections.emptyMap(),
+                    dimensionsQuery != null ? dimensionsQuery : Collections.emptyMap(),
+                    includePayloads, ascending, limit);
+        } catch (SubstrateSdkException | InterruptedException e) {
+            throw MulticloudjUtils.wrapAsIOException("get", namespace, e);
+        }
+    }
+
+    @Override
+    public Set<String> metadata(final String namespace,
+                                final String metadataKey,
+                                final long startTimestampMillis,
+                                final long endTimestampMillis,
+                                final Map<String, String> metadataQuery,
+                                final Map<String, String> dimensionsQuery) throws IOException {
+        checkMetadata(namespace, metadataKey, startTimestampMillis, endTimestampMillis, metadataQuery, dimensionsQuery);
+        checkNamespaceExists(namespace);
+        flushBeforeRead();
+        try {
+            return doMetadata(namespace, metadataKey, startTimestampMillis, endTimestampMillis,
+                    metadataQuery != null ? metadataQuery : Collections.emptyMap(),
+                    dimensionsQuery != null ? dimensionsQuery : Collections.emptyMap());
+        } catch (SubstrateSdkException | InterruptedException e) {
+            throw MulticloudjUtils.wrapAsIOException("metadata", namespace, e);
+        }
+    }
+
+    @Override
+    public List<Event> dimension(final String namespace,
+                                 final String dimensionKey,
+                                 final long startTimestampMillis,
+                                 final long endTimestampMillis,
+                                 final Map<String, String> metadataQuery,
+                                 final Map<String, String> dimensionsQuery) throws IOException {
+        checkDimension(namespace, dimensionKey, startTimestampMillis, endTimestampMillis, metadataQuery, dimensionsQuery);
+        checkNamespaceExists(namespace);
+        flushBeforeRead();
+        try {
+            return doDimension(namespace, dimensionKey, startTimestampMillis, endTimestampMillis,
+                    metadataQuery != null ? metadataQuery : Collections.emptyMap(),
+                    dimensionsQuery != null ? dimensionsQuery : Collections.emptyMap());
+        } catch (SubstrateSdkException | InterruptedException e) {
+            throw MulticloudjUtils.wrapAsIOException("dimension", namespace, e);
+        }
+    }
+
+    @Override
+    public void expire(final String namespace, final long endTimestampMillis) throws IOException {
+        checkExpire(namespace, endTimestampMillis);
+        checkNamespaceExists(namespace);
+        // F4 (correctness / R-D): flush buffered writes before computing the prefix
+        // list to delete. Otherwise events that were still in the in-memory buffer
+        // and within the expiry window survive the call and reappear on later reads.
+        // Matches the pattern used by get(), metadata(), and dimension().
+        flushBeforeRead();
+        try {
+            doExpire(namespace, endTimestampMillis);
+        } catch (SubstrateSdkException e) {
+            throw MulticloudjUtils.wrapAsIOException("expire", namespace, e);
+        }
+    }
+
+    @Override
+    public void close() {
+        if (!closed.compareAndSet(false, true)) {
+            return;
+        }
+        flushExecutor.shutdown();
+        try {
+            if (!flushExecutor.awaitTermination(30, TimeUnit.SECONDS)) {
+                flushExecutor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            flushExecutor.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+        uploadPool.shutdown();
+        try {
+            if (!uploadPool.awaitTermination(30, TimeUnit.SECONDS)) {
+                uploadPool.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            uploadPool.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    void forceFlushNow() {
+        flushBeforeRead();
+    }
+
+    private void flushBeforeRead() {
+        doFlush(false);
+    }
+
+    @Override
+    protected String getObjectKeyPrefix(final String namespace) {
+        return String.format("%s/%s", OBJECT_KEY_PREFIX, trim(namespace));
+    }
+
+    private void doStore(final String namespace, final Collection<Event> batch) throws IOException {
+        SimpleDateFormat minFormatter = new SimpleDateFormat(DIRECTORY_FORMATTER_MIN_PATTERN);
+        minFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        ReentrantLock lock = namespaceLocks.computeIfAbsent(namespace, k -> new ReentrantLock());
+        lock.lock();
+        try {
+            String cycleName = currentFlushCycle.get();
+            for (Event event : batch) {
+                appendEvent(namespace, event, cycleName, minFormatter);
+            }
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    private void appendEvent(final String namespace, final Event event,
+                             final String cycleName, final SimpleDateFormat minFormatter) throws IOException {
+        Map<String, String> metadata = event.getMetadata() != null ? new HashMap<>(event.getMetadata()) : new HashMap<>();
+        Map<String, Double> dimensions = event.getDimensions() != null ? new HashMap<>(event.getDimensions()) : new HashMap<>();
+        byte[] payload = event.getPayload();
+
+        String timeDir = minFormatter.format(new Date(event.getTimestampMillis()));
+        Path cycleDir = bufferRoot.resolve(cycleName);
+        Path namespaceDir = cycleDir.resolve(OBJECT_KEY_PREFIX).resolve(trim(namespace)).resolve(timeDir);
+        Files.createDirectories(namespaceDir);
+
+        String fileBase = timeDir.substring(timeDir.lastIndexOf('/') + 1) + "." + cycleName;
+        Path eventsFile = namespaceDir.resolve(fileBase + ".json");
+        Path payloadFile = namespaceDir.resolve(fileBase + ".b64");
+
+        if (payload != null && payload.length > 0) {
+            String payloadBase64 = Base64.getEncoder().encodeToString(payload);
+            String payloadLine = payloadBase64 + "\n";
+            long offset = payloadOffsets.getUnchecked(payloadFile.toString()).getAndAdd(payloadLine.length());
+            dimensions.put(DIMENSION_KEY_PAYLOAD_OFFSET, (double) offset);
+            dimensions.put(DIMENSION_KEY_PAYLOAD_LENGTH, (double) payloadBase64.length());
+            Files.write(payloadFile, payloadLine.getBytes(StandardCharsets.UTF_8),
+                    StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+        }
+
+        Event toWrite = new Event(event.getTimestampMillis(), metadata, dimensions);
+        String jsonLine = parser.toJson(toWrite) + "\n";
+        Files.write(eventsFile, jsonLine.getBytes(StandardCharsets.UTF_8),
+                StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+    }
+
+    private void flush() {
+        doFlush(true);
+    }
+
+    private void doFlush(boolean waitForInflight) {
+        long startMillis = System.currentTimeMillis();
+        try {
+            SimpleDateFormat cycleFormatter = new SimpleDateFormat(CYCLE_NAME_FORMATTER_PATTERN);
+            cycleFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+            String newCycle = cycleFormatter.format(new Date(System.currentTimeMillis())) + "." + instanceId;
+            String oldCycle = currentFlushCycle.getAndSet(newCycle);
+
+            if (waitForInflight) {
+                try {
+                    TimeUnit.SECONDS.sleep(3);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+            }
+
+            Path oldCycleDir = bufferRoot.resolve(oldCycle);
+            if (!Files.exists(oldCycleDir) || !Files.isDirectory(oldCycleDir)) {
+                return;
+            }
+
+            List<CompletableFuture<Void>> futures = new ArrayList<>();
+            Files.walkFileTree(oldCycleDir, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                    Path relativePath = oldCycleDir.resolve(OBJECT_KEY_PREFIX).getParent().relativize(file);
+                    String blobKey = relativePath.toString().replace(File.separatorChar, '/');
+
+                    futures.add(CompletableFuture.runAsync(() -> {
+                        try {
+                            MulticloudjUtils.uploadFile(bucketClient, blobKey, file.toFile());
+                        } catch (IOException e) {
+                            throw new CompletionException(e);
+                        }
+                    }, uploadPool));
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+
+            boolean allSucceeded = true;
+            for (CompletableFuture<Void> f : futures) {
+                try {
+                    f.get(60, TimeUnit.SECONDS);
+                } catch (Exception e) {
+                    allSucceeded = false;
+                    logger.warn("Failed to upload buffer file during flush cycle '{}': {}", oldCycle, e.getMessage());
+                }
+            }
+
+            if (allSucceeded) {
+                deleteDirectoryRecursively(oldCycleDir);
+            }
+        } catch (Exception e) {
+            logger.warn("Exception during flush", e);
+        } finally {
+            long elapsed = System.currentTimeMillis() - startMillis;
+            logger.debug("Flush cycle elapsed: {}ms", elapsed);
+        }
+    }
+
+    private List<Event> doGet(final String namespace,
+                              final long startTimestampMillis,
+                              final long endTimestampMillis,
+                              final Map<String, String> metadataQuery,
+                              final Map<String, String> dimensionsQuery,
+                              final boolean includePayloads,
+                              final boolean ascending,
+                              final int limit) throws IOException, InterruptedException {
+
+        Set<String> prefixes = MulticloudjUtils.getMatchingKeys(bucketClient, getObjectKeyPrefix(namespace), startTimestampMillis, endTimestampMillis);
+        List<String> jsonKeys = new ArrayList<>();
+        for (String prefix : prefixes) {
+            for (String key : MulticloudjUtils.listKeys(bucketClient, prefix)) {
+                if (key.endsWith(".json")) {
+                    jsonKeys.add(key);
+                }
+            }
+        }
+
+        ConcurrentLinkedQueue<Event> results = new ConcurrentLinkedQueue<>();
+        AtomicBoolean hasFailed = new AtomicBoolean(false);
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+
+        for (String objectKey : jsonKeys) {
+            futures.add(CompletableFuture.runAsync(() -> {
+                try {
+                    List<Event> events = doGetOnObject(objectKey, startTimestampMillis, endTimestampMillis,
+                            metadataQuery, dimensionsQuery, includePayloads);
+                    results.addAll(events);
+                } catch (IOException e) {
+                    hasFailed.set(true);
+                    logger.warn("Exception on get call for key '{}': {}", objectKey, e.getMessage());
+                }
+            }, uploadPool));
+        }
+
+        for (CompletableFuture<Void> f : futures) {
+            try {
+                f.get(60, TimeUnit.SECONDS);
+            } catch (ExecutionException | TimeoutException e) {
+                hasFailed.set(true);
+            }
+        }
+
+        if (hasFailed.get()) {
+            throw new IOException("exception on get call to blob storage");
+        }
+
+        List<Event> sorted = new ArrayList<>(results);
+        sorted.sort((e1, e2) -> {
+            if (e1.getTimestampMillis() < e2.getTimestampMillis()) return ascending ? -1 : 1;
+            if (e1.getTimestampMillis() > e2.getTimestampMillis()) return ascending ? 1 : -1;
+            return 0;
+        });
+
+        if (limit > 0) {
+            return sorted.subList(0, Math.min(limit, sorted.size()));
+        }
+        return sorted;
+    }
+
+    private List<Event> doGetOnObject(final String objectKey,
+                                      final long startTimestampMillis,
+                                      final long endTimestampMillis,
+                                      final Map<String, String> metadataQuery,
+                                      final Map<String, String> dimensionsQuery,
+                                      final boolean includePayloads) throws IOException {
+        List<Event> results = new ArrayList<>();
+        byte[] content = MulticloudjUtils.download(bucketClient, objectKey);
+        String[] lines = new String(content, StandardCharsets.UTF_8).split("\n");
+
+        for (String line : lines) {
+            if (line.trim().isEmpty()) continue;
+            Event event = parser.fromJson(line, Event.class);
+            if (event.getTimestampMillis() < startTimestampMillis || event.getTimestampMillis() > endTimestampMillis) {
+                continue;
+            }
+            if (!MulticloudjUtils.matchesMetadata(event.getMetadata(), metadataQuery)) {
+                continue;
+            }
+            if (!MulticloudjUtils.matchesDimensions(event.getDimensions(), dimensionsQuery)) {
+                continue;
+            }
+
+            if (includePayloads
+                    && event.getDimensions().containsKey(DIMENSION_KEY_PAYLOAD_OFFSET)
+                    && event.getDimensions().containsKey(DIMENSION_KEY_PAYLOAD_LENGTH)) {
+                long offset = event.getDimensions().get(DIMENSION_KEY_PAYLOAD_OFFSET).longValue();
+                long length = event.getDimensions().get(DIMENSION_KEY_PAYLOAD_LENGTH).longValue();
+                String payloadKey = objectKey.substring(0, objectKey.lastIndexOf(".json")) + ".b64";
+                byte[] payloadBase64Bytes = MulticloudjUtils.downloadRange(bucketClient, payloadKey, offset, offset + length - 1);
+                byte[] payload = Base64.getDecoder().decode(new String(payloadBase64Bytes, StandardCharsets.UTF_8).trim());
+                results.add(new Event(event.getTimestampMillis(), event.getMetadata(), event.getDimensions(), payload));
+            } else {
+                results.add(event);
+            }
+        }
+        return results;
+    }
+
+    private Set<String> doMetadata(final String namespace,
+                                   final String metadataKey,
+                                   final long startTimestampMillis,
+                                   final long endTimestampMillis,
+                                   final Map<String, String> metadataQuery,
+                                   final Map<String, String> dimensionsQuery) throws IOException, InterruptedException {
+
+        Set<String> prefixes = MulticloudjUtils.getMatchingKeys(bucketClient, getObjectKeyPrefix(namespace), startTimestampMillis, endTimestampMillis);
+        Set<String> results = ConcurrentHashMap.newKeySet();
+        AtomicBoolean hasFailed = new AtomicBoolean(false);
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+
+        for (String prefix : prefixes) {
+            for (String key : MulticloudjUtils.listKeys(bucketClient, prefix)) {
+                if (!key.endsWith(".json")) continue;
+                futures.add(CompletableFuture.runAsync(() -> {
+                    try {
+                        byte[] content = MulticloudjUtils.download(bucketClient, key);
+                        String[] lines = new String(content, StandardCharsets.UTF_8).split("\n");
+                        for (String line : lines) {
+                            if (line.trim().isEmpty()) continue;
+                            Event event = parser.fromJson(line, Event.class);
+                            if (event.getTimestampMillis() < startTimestampMillis || event.getTimestampMillis() > endTimestampMillis) continue;
+                            if (!MulticloudjUtils.matchesMetadata(event.getMetadata(), metadataQuery)) continue;
+                            if (!MulticloudjUtils.matchesDimensions(event.getDimensions(), dimensionsQuery)) continue;
+                            String val = event.getMetadata().get(metadataKey);
+                            if (val != null) results.add(val);
+                        }
+                    } catch (IOException e) {
+                        hasFailed.set(true);
+                        logger.warn("Exception on metadata call for key '{}': {}", key, e.getMessage());
+                    }
+                }, uploadPool));
+            }
+        }
+
+        for (CompletableFuture<Void> f : futures) {
+            try {
+                f.get(60, TimeUnit.SECONDS);
+            } catch (ExecutionException | TimeoutException e) {
+                hasFailed.set(true);
+            }
+        }
+
+        if (hasFailed.get()) {
+            throw new IOException("exception on metadata call to blob storage");
+        }
+        return results;
+    }
+
+    private List<Event> doDimension(final String namespace,
+                                    final String dimensionKey,
+                                    final long startTimestampMillis,
+                                    final long endTimestampMillis,
+                                    final Map<String, String> metadataQuery,
+                                    final Map<String, String> dimensionsQuery) throws IOException, InterruptedException {
+
+        Set<String> prefixes = MulticloudjUtils.getMatchingKeys(bucketClient, getObjectKeyPrefix(namespace), startTimestampMillis, endTimestampMillis);
+        ConcurrentLinkedQueue<Event> results = new ConcurrentLinkedQueue<>();
+        AtomicBoolean hasFailed = new AtomicBoolean(false);
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+
+        for (String prefix : prefixes) {
+            for (String key : MulticloudjUtils.listKeys(bucketClient, prefix)) {
+                if (!key.endsWith(".json")) continue;
+                futures.add(CompletableFuture.runAsync(() -> {
+                    try {
+                        byte[] content = MulticloudjUtils.download(bucketClient, key);
+                        String[] lines = new String(content, StandardCharsets.UTF_8).split("\n");
+                        for (String line : lines) {
+                            if (line.trim().isEmpty()) continue;
+                            Event event = parser.fromJson(line, Event.class);
+                            if (event.getTimestampMillis() < startTimestampMillis || event.getTimestampMillis() > endTimestampMillis) continue;
+                            if (!MulticloudjUtils.matchesMetadata(event.getMetadata(), metadataQuery)) continue;
+                            if (!MulticloudjUtils.matchesDimensions(event.getDimensions(), dimensionsQuery)) continue;
+                            Double val = event.getDimensions().get(dimensionKey);
+                            if (val != null) {
+                                results.add(new Event(event.getTimestampMillis(), Collections.emptyMap(),
+                                        Collections.singletonMap(dimensionKey, val)));
+                            }
+                        }
+                    } catch (IOException e) {
+                        hasFailed.set(true);
+                        logger.warn("Exception on dimension call for key '{}': {}", key, e.getMessage());
+                    }
+                }, uploadPool));
+            }
+        }
+
+        for (CompletableFuture<Void> f : futures) {
+            try {
+                f.get(60, TimeUnit.SECONDS);
+            } catch (ExecutionException | TimeoutException e) {
+                hasFailed.set(true);
+            }
+        }
+
+        if (hasFailed.get()) {
+            throw new IOException("exception on dimension call to blob storage");
+        }
+        return new ArrayList<>(results);
+    }
+
+    private void doExpire(final String namespace, final long endTimestampMillis) throws IOException {
+        SimpleDateFormat minFormatter = new SimpleDateFormat(DIRECTORY_FORMATTER_MIN_PATTERN);
+        minFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        List<String> allKeys = MulticloudjUtils.listKeys(bucketClient, getObjectKeyPrefix(namespace));
+        List<String> toDelete = new ArrayList<>();
+
+        for (String key : allKeys) {
+            if (key.endsWith(NAMESPACE_IDENTIFIER)) continue;
+            long keyTimestamp = extractTimestampFromKey(key, namespace);
+            if (keyTimestamp >= 0 && keyTimestamp < endTimestampMillis) {
+                toDelete.add(key);
+            }
+        }
+
+        MulticloudjUtils.deleteBatched(bucketClient, toDelete);
+    }
+
+    private long extractTimestampFromKey(final String key, final String namespace) {
+        try {
+            String prefix = getObjectKeyPrefix(namespace) + "/";
+            if (!key.startsWith(prefix)) return -1;
+            String afterPrefix = key.substring(prefix.length());
+            // afterPrefix looks like: yyyy/MM/dd/HH/mm.<cycle>.json or .b64
+            if (afterPrefix.length() < 16) return -1;
+            String timePart = afterPrefix.substring(0, 16); // yyyy/MM/dd/HH/mm
+            SimpleDateFormat fmt = new SimpleDateFormat(DIRECTORY_FORMATTER_MIN_PATTERN);
+            fmt.setTimeZone(TimeZone.getTimeZone("UTC"));
+            Date parsed = fmt.parse(timePart);
+            return parsed.getTime();
+        } catch (Exception e) {
+            return -1;
+        }
+    }
+
+    /**
+     * Validate and canonicalize the user-supplied buffer directory path.
+     *
+     * <p>F3 (CWE-22 / path traversal) guard. We reject any input that contains
+     * a {@code ..} segment outright — even after normalization, a caller passing
+     * {@code "/tmp/../etc/passwd"} is exhibiting traversal intent. We also reject
+     * inputs that resolve to an existing non-directory (regular file, broken
+     * symlink, etc.) so the constructor cannot be tricked into using a sensitive
+     * location as a "buffer dir".
+     */
+    private static Path validateAndCanonicalizeBufferDirectory(final String bufferDirectory) {
+        // Refuse traversal-style inputs without trying to be clever about resolving them.
+        // Any segment equal to ".." is rejected, irrespective of whether the resulting
+        // canonical path would stay inside an "expected base" - the project has no
+        // standardized base, so the safest rule is "no .. in input".
+        final Path raw;
+        try {
+            raw = Paths.get(bufferDirectory);
+        } catch (InvalidPathException e) {
+            throw new IllegalArgumentException("invalid buffer directory path: " + bufferDirectory, e);
+        }
+        for (Path segment : raw) {
+            if ("..".equals(segment.toString())) {
+                throw new IllegalArgumentException(
+                        "buffer directory path must not contain '..' segments: " + bufferDirectory);
+            }
+        }
+        final Path canonical = raw.normalize().toAbsolutePath();
+        if (Files.exists(canonical) && !Files.isDirectory(canonical)) {
+            throw new IllegalArgumentException(
+                    "buffer directory path exists but is not a directory: " + canonical);
+        }
+        return canonical;
+    }
+
+    /**
+     * Create the per-instance buffer directory with owner-only (700) permissions on POSIX
+     * systems. F2 guard (CWE-276/200): buffered events may contain PII; world-readable
+     * directories leak that data to any local user.
+     *
+     * <p>On non-POSIX file systems (e.g. Windows) the method falls back to {@code File}
+     * read-permission tweaks, which is the strongest portable approximation Java offers.
+     */
+    private static void createBufferRootWithRestrictivePermissions(final Path bufferRoot) throws IOException {
+        final boolean posix = FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
+        if (posix) {
+            // Create any missing parents first - createDirectories(path, attrs) applies the attrs
+            // to every directory it creates, which on a multi-level parent tree could clobber an
+            // existing parent's permissions. Build parents without attrs, then create the leaf
+            // with 700.
+            final Path parent = bufferRoot.getParent();
+            if (parent != null) {
+                Files.createDirectories(parent);
+            }
+            if (!Files.exists(bufferRoot)) {
+                Files.createDirectory(bufferRoot,
+                        PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwx------")));
+            } else {
+                Files.setPosixFilePermissions(bufferRoot,
+                        PosixFilePermissions.fromString("rwx------"));
+            }
+        } else {
+            Files.createDirectories(bufferRoot);
+            // Best-effort on non-POSIX (Windows): strip world-readable bit, then re-grant owner.
+            File f = bufferRoot.toFile();
+            //noinspection ResultOfMethodCallIgnored
+            f.setReadable(false, false);
+            //noinspection ResultOfMethodCallIgnored
+            f.setReadable(true, true);
+            //noinspection ResultOfMethodCallIgnored
+            f.setWritable(false, false);
+            //noinspection ResultOfMethodCallIgnored
+            f.setWritable(true, true);
+            //noinspection ResultOfMethodCallIgnored
+            f.setExecutable(false, false);
+            //noinspection ResultOfMethodCallIgnored
+            f.setExecutable(true, true);
+        }
+    }
+
+    private static void deleteDirectoryRecursively(final Path dir) {
+        try {
+            Files.walkFileTree(dir, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    Files.delete(file);
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path d, IOException exc) throws IOException {
+                    Files.delete(d);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (IOException e) {
+            logger.warn("Failed to delete directory '{}': {}", dir, e.getMessage());
+        }
+    }
+}

--- a/cantor-multicloudj/src/main/java/com/salesforce/cantor/multicloudj/MulticloudjUtils.java
+++ b/cantor-multicloudj/src/main/java/com/salesforce/cantor/multicloudj/MulticloudjUtils.java
@@ -1,0 +1,443 @@
+/*
+ * Copyright (c) 2020, Salesforce.com, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.cantor.multicloudj;
+
+import com.salesforce.multicloudj.blob.client.BucketClient;
+import com.salesforce.multicloudj.blob.driver.BlobIdentifier;
+import com.salesforce.multicloudj.blob.driver.BlobInfo;
+import com.salesforce.multicloudj.blob.driver.DownloadRequest;
+import com.salesforce.multicloudj.blob.driver.ListBlobsRequest;
+import com.salesforce.multicloudj.blob.driver.UploadRequest;
+import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.text.SimpleDateFormat;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+final class MulticloudjUtils {
+    private static final Logger logger = LoggerFactory.getLogger(MulticloudjUtils.class);
+    private static final int DELETE_BATCH_MAX = 100;
+    static final String DIRECTORY_FORMATTER_MIN_PATTERN = "yyyy/MM/dd/HH/mm";
+    private static final String DIRECTORY_FORMATTER_HOUR_PATTERN = "yyyy/MM/dd/HH/";
+    private static final AtomicBoolean rangeDownloadWarningLogged = new AtomicBoolean(false);
+
+    /**
+     * Default upper bound on the size of a single blob download (256 MiB).
+     * Without this guard, a single malicious or accidentally-large blob could
+     * be loaded fully into a {@link ByteArrayOutputStream} and trigger an OOM
+     * in the calling JVM (CWE-400). Callers can override via
+     * {@link #setMaxDownloadSizeBytes(long)}.
+     */
+    private static final long DEFAULT_MAX_DOWNLOAD_SIZE_BYTES = 256L * 1024L * 1024L;
+    private static volatile long maxDownloadSizeBytes = DEFAULT_MAX_DOWNLOAD_SIZE_BYTES;
+
+    private MulticloudjUtils() {}
+
+    /**
+     * Configure the maximum allowed size (in bytes) of a single blob download.
+     * Calls to {@link #download(BucketClient, String)} or
+     * {@link #downloadRange(BucketClient, String, long, long)} that would
+     * exceed this limit throw {@link IOException} instead of OOMing.
+     *
+     * @param bytes maximum number of bytes to buffer for a single download;
+     *              must be strictly positive
+     */
+    static void setMaxDownloadSizeBytes(long bytes) {
+        if (bytes <= 0) {
+            throw new IllegalArgumentException("max download size must be positive");
+        }
+        maxDownloadSizeBytes = bytes;
+    }
+
+    /** Returns the currently configured max-download-size limit, in bytes. */
+    static long getMaxDownloadSizeBytes() {
+        return maxDownloadSizeBytes;
+    }
+
+    static boolean doesObjectExist(BucketClient bc, String key) throws IOException {
+        try {
+            return bc.doesObjectExist(key, null);
+        } catch (SubstrateSdkException e) {
+            throw wrapAsIOException("doesObjectExist", key, e);
+        }
+    }
+
+    static void upload(BucketClient bc, String key, byte[] bytes) throws IOException {
+        try {
+            bc.upload(UploadRequest.builder().withKey(key).build(), bytes);
+        } catch (SubstrateSdkException e) {
+            throw wrapAsIOException("upload", key, e);
+        }
+    }
+
+    static void upload(BucketClient bc, String key, InputStream in) throws IOException {
+        try {
+            bc.upload(UploadRequest.builder().withKey(key).build(), in);
+        } catch (SubstrateSdkException e) {
+            throw wrapAsIOException("upload", key, e);
+        }
+    }
+
+    static void uploadFile(BucketClient bc, String key, File file) throws IOException {
+        try (FileInputStream fis = new FileInputStream(file)) {
+            bc.upload(UploadRequest.builder().withKey(key).build(), fis);
+        } catch (SubstrateSdkException e) {
+            throw wrapAsIOException("uploadFile", key, e);
+        }
+    }
+
+    static byte[] download(BucketClient bc, String key) throws IOException {
+        try {
+            BoundedByteArrayOutputStream bounded = new BoundedByteArrayOutputStream(maxDownloadSizeBytes, key);
+            bc.download(DownloadRequest.builder().withKey(key).build(), bounded);
+            return bounded.toByteArray();
+        } catch (BoundedByteArrayOutputStream.SizeLimitExceededException e) {
+            // Cap-exceeded: surface a clear IOException with the configured limit.
+            throw new IOException(String.format(
+                    "blob '%s' exceeds maximum download size (limit=%d bytes)",
+                    key, maxDownloadSizeBytes), e);
+        } catch (SubstrateSdkException e) {
+            // Some providers may wrap the bounded-stream IOException; unwrap if so.
+            if (isBoundedSizeLimitCause(e)) {
+                throw new IOException(String.format(
+                        "blob '%s' exceeds maximum download size (limit=%d bytes)",
+                        key, maxDownloadSizeBytes), e);
+            }
+            throw wrapAsIOException("download", key, e);
+        }
+    }
+
+    static byte[] downloadRange(BucketClient bc, String key, long startInclusive, long endInclusive) throws IOException {
+        // Refuse upfront if the requested range itself exceeds the cap.
+        final long requested = endInclusive - startInclusive + 1;
+        if (requested > maxDownloadSizeBytes) {
+            throw new IOException(String.format(
+                    "requested range for blob '%s' (%d bytes) exceeds maximum download size (limit=%d bytes)",
+                    key, requested, maxDownloadSizeBytes));
+        }
+        try {
+            BoundedByteArrayOutputStream bounded = new BoundedByteArrayOutputStream(maxDownloadSizeBytes, key);
+            bc.download(DownloadRequest.builder().withKey(key).withRange(startInclusive, endInclusive).build(), bounded);
+            return bounded.toByteArray();
+        } catch (BoundedByteArrayOutputStream.SizeLimitExceededException e) {
+            throw new IOException(String.format(
+                    "blob '%s' range exceeds maximum download size (limit=%d bytes)",
+                    key, maxDownloadSizeBytes), e);
+        } catch (SubstrateSdkException | UnsupportedOperationException e) {
+            String msg = e.getMessage() != null ? e.getMessage().toLowerCase() : "";
+            if (e instanceof UnsupportedOperationException || msg.contains("range")) {
+                if (rangeDownloadWarningLogged.compareAndSet(false, true)) {
+                    logger.warn("Range download not supported by provider; falling back to full download + slice for key '{}'", key);
+                }
+                byte[] full = download(bc, key);
+                int start = (int) startInclusive;
+                int end = (int) Math.min(endInclusive + 1, full.length);
+                return Arrays.copyOfRange(full, start, end);
+            }
+            if (isBoundedSizeLimitCause(e)) {
+                throw new IOException(String.format(
+                        "blob '%s' range exceeds maximum download size (limit=%d bytes)",
+                        key, maxDownloadSizeBytes), e);
+            }
+            throw wrapAsIOException("downloadRange", key, e);
+        }
+    }
+
+    private static boolean isBoundedSizeLimitCause(final Throwable t) {
+        Throwable cur = t;
+        while (cur != null) {
+            if (cur instanceof BoundedByteArrayOutputStream.SizeLimitExceededException) {
+                return true;
+            }
+            cur = cur.getCause();
+        }
+        return false;
+    }
+
+    /**
+     * {@link ByteArrayOutputStream} variant that refuses to grow beyond a
+     * configured byte limit — the downloader writes blob bytes into this stream,
+     * so capping it bounds peak heap usage per download (F1 / CWE-400 guard).
+     */
+    static final class BoundedByteArrayOutputStream extends ByteArrayOutputStream {
+        private final long limit;
+        private final String key;
+
+        BoundedByteArrayOutputStream(long limit, String key) {
+            this.limit = limit;
+            this.key = key;
+        }
+
+        @Override
+        public synchronized void write(int b) {
+            checkSize(1);
+            super.write(b);
+        }
+
+        @Override
+        public synchronized void write(byte[] b, int off, int len) {
+            checkSize(len);
+            super.write(b, off, len);
+        }
+
+        @Override
+        public synchronized void writeBytes(byte[] b) {
+            checkSize(b.length);
+            super.writeBytes(b);
+        }
+
+        private void checkSize(int incoming) {
+            long projected = (long) size() + (long) incoming;
+            if (projected > limit) {
+                throw new SizeLimitExceededException(String.format(
+                        "blob '%s' exceeds maximum download size (limit=%d bytes, attempted=%d bytes)",
+                        key, limit, projected));
+            }
+        }
+
+        /** Unchecked so it propagates cleanly through SDK {@code OutputStream.write(...)} callers. */
+        static final class SizeLimitExceededException extends RuntimeException {
+            private static final long serialVersionUID = 1L;
+            SizeLimitExceededException(String msg) {
+                super(msg);
+            }
+        }
+    }
+
+    static List<String> listKeys(BucketClient bc, String prefix) throws IOException {
+        try {
+            List<String> keys = new ArrayList<>();
+            Iterator<BlobInfo> it = bc.list(ListBlobsRequest.builder().withPrefix(prefix).build());
+            while (it.hasNext()) {
+                keys.add(it.next().getKey());
+            }
+            return keys;
+        } catch (SubstrateSdkException e) {
+            throw wrapAsIOException("listKeys", prefix, e);
+        }
+    }
+
+    static List<String> listKeysOrdered(BucketClient bc, String prefix, int start, int count) throws IOException {
+        try {
+            List<String> keys = new ArrayList<>();
+            Iterator<BlobInfo> it = bc.list(ListBlobsRequest.builder().withPrefix(prefix).build());
+            int index = 0;
+            while (it.hasNext()) {
+                String key = it.next().getKey();
+                if (index >= start) {
+                    keys.add(key);
+                    if (count >= 0 && keys.size() >= count) {
+                        break;
+                    }
+                }
+                index++;
+            }
+            return keys;
+        } catch (SubstrateSdkException e) {
+            throw wrapAsIOException("listKeysOrdered", prefix, e);
+        }
+    }
+
+    static int countKeys(BucketClient bc, String prefix) throws IOException {
+        try {
+            int count = 0;
+            Iterator<BlobInfo> it = bc.list(ListBlobsRequest.builder().withPrefix(prefix).build());
+            while (it.hasNext()) {
+                it.next();
+                count++;
+            }
+            return count;
+        } catch (SubstrateSdkException e) {
+            throw wrapAsIOException("countKeys", prefix, e);
+        }
+    }
+
+    static void deleteAllUnderPrefix(BucketClient bc, String prefix) throws IOException {
+        List<String> keys = listKeys(bc, prefix);
+        deleteBatched(bc, keys);
+    }
+
+    static void deleteBatched(BucketClient bc, Collection<String> keys) throws IOException {
+        if (keys == null || keys.isEmpty()) {
+            return;
+        }
+        try {
+            List<String> keyList = new ArrayList<>(keys);
+            for (int i = 0; i < keyList.size(); i += DELETE_BATCH_MAX) {
+                List<String> batch = keyList.subList(i, Math.min(i + DELETE_BATCH_MAX, keyList.size()));
+                Collection<BlobIdentifier> identifiers = new ArrayList<>(batch.size());
+                for (String key : batch) {
+                    identifiers.add(new BlobIdentifier(key, null));
+                }
+                bc.delete(identifiers);
+            }
+        } catch (SubstrateSdkException e) {
+            throw wrapAsIOException("deleteBatched", "batch", e);
+        }
+    }
+
+    static Set<String> getMatchingKeys(BucketClient bc, String namespaceKeyPrefix, long startMs, long endMs) throws IOException {
+        if (startMs > endMs) {
+            throw new IllegalArgumentException("start must be <= end");
+        }
+
+        SimpleDateFormat directoryFormatterMin = new SimpleDateFormat(DIRECTORY_FORMATTER_MIN_PATTERN);
+        SimpleDateFormat directoryFormatterHour = new SimpleDateFormat(DIRECTORY_FORMATTER_HOUR_PATTERN);
+        directoryFormatterMin.setTimeZone(TimeZone.getTimeZone("UTC"));
+        directoryFormatterHour.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        Set<String> prefixes = new HashSet<>();
+        long current = startMs;
+        while (current <= endMs) {
+            if (current + TimeUnit.HOURS.toMillis(1) <= endMs) {
+                prefixes.add(String.format("%s/%s", namespaceKeyPrefix, directoryFormatterHour.format(new Date(current))));
+                current = current / (60 * 60 * 1000) * (60 * 60 * 1000);
+                current += TimeUnit.HOURS.toMillis(1);
+            } else {
+                prefixes.add(String.format("%s/%s", namespaceKeyPrefix, directoryFormatterMin.format(new Date(current))));
+                current += TimeUnit.MINUTES.toMillis(1);
+            }
+        }
+        prefixes.add(String.format("%s/%s", namespaceKeyPrefix, directoryFormatterMin.format(new Date(endMs))));
+
+        return prefixes;
+    }
+
+    static boolean matchesMetadata(Map<String, String> metadata, Map<String, String> query) {
+        if (query == null || query.isEmpty()) {
+            return true;
+        }
+        for (Map.Entry<String, String> entry : query.entrySet()) {
+            String key = entry.getKey();
+            String queryValue = entry.getValue();
+            String actualValue = metadata != null ? metadata.get(key) : null;
+
+            if (actualValue == null) {
+                return false;
+            }
+
+            if (queryValue.startsWith("!~")) {
+                String pattern = queryValue.substring(2);
+                if (matchesLikePattern(actualValue, pattern)) {
+                    return false;
+                }
+            } else if (queryValue.startsWith("~")) {
+                String pattern = queryValue.substring(1);
+                if (!matchesLikePattern(actualValue, pattern)) {
+                    return false;
+                }
+            } else if (queryValue.startsWith("!=")) {
+                String expected = queryValue.substring(2);
+                if (actualValue.equals(expected)) {
+                    return false;
+                }
+            } else if (queryValue.startsWith("=")) {
+                String expected = queryValue.substring(1);
+                if (!actualValue.equals(expected)) {
+                    return false;
+                }
+            } else {
+                if (!actualValue.equals(queryValue)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    static boolean matchesDimensions(Map<String, Double> dimensions, Map<String, String> query) {
+        if (query == null || query.isEmpty()) {
+            return true;
+        }
+        for (Map.Entry<String, String> entry : query.entrySet()) {
+            String key = entry.getKey();
+            String queryValue = entry.getValue();
+            Double actualValue = dimensions != null ? dimensions.get(key) : null;
+
+            if (actualValue == null) {
+                return false;
+            }
+
+            if (queryValue.contains("..")) {
+                int dotIdx = queryValue.indexOf("..");
+                double low = Double.parseDouble(queryValue.substring(0, dotIdx));
+                double high = Double.parseDouble(queryValue.substring(dotIdx + 2));
+                if (actualValue < low || actualValue > high) {
+                    return false;
+                }
+            } else if (queryValue.startsWith(">=")) {
+                double threshold = Double.parseDouble(queryValue.substring(2));
+                if (actualValue < threshold) {
+                    return false;
+                }
+            } else if (queryValue.startsWith("<=")) {
+                double threshold = Double.parseDouble(queryValue.substring(2));
+                if (actualValue > threshold) {
+                    return false;
+                }
+            } else if (queryValue.startsWith(">")) {
+                double threshold = Double.parseDouble(queryValue.substring(1));
+                if (actualValue <= threshold) {
+                    return false;
+                }
+            } else if (queryValue.startsWith("<")) {
+                double threshold = Double.parseDouble(queryValue.substring(1));
+                if (actualValue >= threshold) {
+                    return false;
+                }
+            } else if (queryValue.startsWith("!=")) {
+                double expected = Double.parseDouble(queryValue.substring(2));
+                if (Double.compare(actualValue, expected) == 0) {
+                    return false;
+                }
+            } else if (queryValue.startsWith("=")) {
+                double expected = Double.parseDouble(queryValue.substring(1));
+                if (Double.compare(actualValue, expected) != 0) {
+                    return false;
+                }
+            } else {
+                double expected = Double.parseDouble(queryValue);
+                if (Double.compare(actualValue, expected) != 0) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    static IOException wrapAsIOException(String op, String namespace, Throwable cause) {
+        return new IOException(String.format("exception during %s on namespace '%s'", op, namespace), cause);
+    }
+
+    private static boolean matchesLikePattern(String value, String pattern) {
+        if (!pattern.contains("*")) {
+            return value.equals(pattern);
+        }
+        String regex = buildRegexFromGlob(pattern);
+        return value.matches(regex);
+    }
+
+    private static String buildRegexFromGlob(String glob) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < glob.length(); i++) {
+            char c = glob.charAt(i);
+            if (c == '*') {
+                sb.append(".*");
+            } else if ("\\[]{}()^$.|?+".indexOf(c) >= 0) {
+                sb.append('\\').append(c);
+            } else {
+                sb.append(c);
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/cantor-multicloudj/src/main/java/com/salesforce/cantor/multicloudj/ObjectsOnMulticloudj.java
+++ b/cantor-multicloudj/src/main/java/com/salesforce/cantor/multicloudj/ObjectsOnMulticloudj.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2020, Salesforce.com, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.cantor.multicloudj;
+
+import com.salesforce.multicloudj.blob.client.BucketClient;
+import com.salesforce.multicloudj.common.exceptions.SubstrateSdkException;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.salesforce.cantor.common.ObjectsPreconditions.*;
+
+public final class ObjectsOnMulticloudj extends AbstractBaseMulticloudjNamespaceable implements StreamingObjects {
+    private static final String OBJECT_KEY_PREFIX = "cantor-objects";
+
+    public ObjectsOnMulticloudj(final BucketClient bucketClient) throws IOException {
+        super(bucketClient, "objects");
+    }
+
+    @Override
+    public void store(final String namespace, final String key, final byte[] bytes) throws IOException {
+        checkStore(namespace, key, bytes);
+        checkNamespaceExists(namespace);
+        try {
+            MulticloudjUtils.upload(bucketClient, getObjectKey(namespace, key), bytes);
+        } catch (final SubstrateSdkException e) {
+            throw MulticloudjUtils.wrapAsIOException("store", namespace, e);
+        }
+    }
+
+    @Override
+    public void store(final String namespace, final String key, final InputStream stream, final long length) throws IOException {
+        checkStore(namespace, key, new byte[0]);
+        checkNamespaceExists(namespace);
+        try {
+            MulticloudjUtils.upload(bucketClient, getObjectKey(namespace, key), stream);
+        } catch (final SubstrateSdkException e) {
+            throw MulticloudjUtils.wrapAsIOException("store(stream)", namespace, e);
+        }
+    }
+
+    @Override
+    public byte[] get(final String namespace, final String key) throws IOException {
+        checkGet(namespace, key);
+        try {
+            if (!MulticloudjUtils.doesObjectExist(bucketClient, getObjectKey(namespace, key))) {
+                return null;
+            }
+            return MulticloudjUtils.download(bucketClient, getObjectKey(namespace, key));
+        } catch (final SubstrateSdkException e) {
+            throw MulticloudjUtils.wrapAsIOException("get", namespace, e);
+        }
+    }
+
+    @Override
+    public InputStream stream(final String namespace, final String key) throws IOException {
+        checkGet(namespace, key);
+        try {
+            if (!MulticloudjUtils.doesObjectExist(bucketClient, getObjectKey(namespace, key))) {
+                return null;
+            }
+            byte[] data = MulticloudjUtils.download(bucketClient, getObjectKey(namespace, key));
+            return new ByteArrayInputStream(data);
+        } catch (final SubstrateSdkException e) {
+            throw MulticloudjUtils.wrapAsIOException("stream", namespace, e);
+        }
+    }
+
+    @Override
+    public boolean delete(final String namespace, final String key) throws IOException {
+        checkDelete(namespace, key);
+        try {
+            boolean existed = MulticloudjUtils.doesObjectExist(bucketClient, getObjectKey(namespace, key));
+            if (existed) {
+                bucketClient.delete(getObjectKey(namespace, key), null);
+            }
+            return existed;
+        } catch (final SubstrateSdkException e) {
+            throw MulticloudjUtils.wrapAsIOException("delete", namespace, e);
+        }
+    }
+
+    @Override
+    public Collection<String> keys(final String namespace, final int start, final int count) throws IOException {
+        return keys(namespace, "", start, count);
+    }
+
+    @Override
+    public Collection<String> keys(final String namespace, final String prefix, final int start, final int count) throws IOException {
+        checkKeys(namespace, start, count);
+        try {
+            final String searchPrefix = getObjectKeyPrefix(namespace) + "/" + prefix;
+            final String stripPrefix = getObjectKeyPrefix(namespace) + "/";
+            List<String> allKeys = MulticloudjUtils.listKeysOrdered(bucketClient, searchPrefix, 0, -1);
+            List<String> filtered = allKeys.stream()
+                    .map(k -> k.substring(stripPrefix.length()))
+                    .filter(k -> !k.equals(NAMESPACE_IDENTIFIER))
+                    .collect(Collectors.toList());
+
+            if (start >= filtered.size()) {
+                return List.of();
+            }
+            int end = (count < 0) ? filtered.size() : Math.min(start + count, filtered.size());
+            return filtered.subList(start, end);
+        } catch (final SubstrateSdkException e) {
+            throw MulticloudjUtils.wrapAsIOException("keys", namespace, e);
+        }
+    }
+
+    @Override
+    public int size(final String namespace) throws IOException {
+        checkSize(namespace);
+        try {
+            int total = MulticloudjUtils.countKeys(bucketClient, getObjectKeyPrefix(namespace));
+            String markerKey = getObjectKeyPrefix(namespace) + "/" + NAMESPACE_IDENTIFIER;
+            if (MulticloudjUtils.doesObjectExist(bucketClient, markerKey)) {
+                total--;
+            }
+            return total;
+        } catch (final SubstrateSdkException e) {
+            throw MulticloudjUtils.wrapAsIOException("size", namespace, e);
+        }
+    }
+
+    @Override
+    protected String getObjectKeyPrefix(final String namespace) {
+        return String.format("%s/%s", OBJECT_KEY_PREFIX, trim(namespace));
+    }
+
+    private String getObjectKey(final String namespace, final String key) {
+        return String.format("%s/%s", getObjectKeyPrefix(namespace), key);
+    }
+}

--- a/cantor-multicloudj/src/main/java/com/salesforce/cantor/multicloudj/StreamingObjects.java
+++ b/cantor-multicloudj/src/main/java/com/salesforce/cantor/multicloudj/StreamingObjects.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2020, Salesforce.com, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.cantor.multicloudj;
+
+import com.salesforce.cantor.Objects;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Extension of the {@link Objects} interface to implement storing/streaming objects that are too large
+ * to store/get as whole {@code byte[]}.
+ */
+public interface StreamingObjects extends Objects {
+    /**
+     * Stores the given object by streaming the content to the underlying storage
+     * @param namespace the namespace to store in
+     * @param key the key for the object
+     * @param stream the content of the object as an {@link InputStream}
+     * @param length the full length of the content
+     */
+    void store(String namespace, String key, InputStream stream, long length) throws IOException;
+
+    /**
+     * Gets the object corresponding to the given namespace/key as an {@link InputStream}
+     * @param namespace the namespace of the object
+     * @param key the key of the object
+     * @return an {@link InputStream} for the stored object/null if it doesn't exist
+     */
+    InputStream stream(String namespace, String key) throws IOException;
+}

--- a/cantor-multicloudj/src/test/java/com/salesforce/cantor/multicloudj/AbstractBaseMulticloudjNamespaceableTest.java
+++ b/cantor-multicloudj/src/test/java/com/salesforce/cantor/multicloudj/AbstractBaseMulticloudjNamespaceableTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2020, Salesforce.com, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.cantor.multicloudj;
+
+import com.salesforce.multicloudj.blob.client.BucketClient;
+import com.salesforce.cantor.multicloudj.support.InMemoryBucketClients;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+public class AbstractBaseMulticloudjNamespaceableTest {
+
+    /**
+     * Concrete subclass for testing the abstract base class.
+     */
+    private static class Probe extends AbstractBaseMulticloudjNamespaceable {
+        Probe(BucketClient bucketClient) throws IOException {
+            super(bucketClient, "test");
+        }
+
+        @Override
+        protected String getObjectKeyPrefix(String namespace) {
+            return "cantor-test/" + trim(namespace);
+        }
+    }
+
+    @Test
+    public void testConstructor_validatesBucketReachable() throws IOException {
+        BucketClient bc = InMemoryBucketClients.fresh();
+        Probe probe = new Probe(bc);
+        assertNotNull(probe);
+    }
+
+    @Test
+    public void testCreate_writesNamespaceMarkerAtExpectedKey() throws IOException {
+        BucketClient bc = InMemoryBucketClients.fresh();
+        Probe probe = new Probe(bc);
+
+        probe.create("foo");
+
+        String expectedMarkerKey = "cantor-test/" + AbstractBaseMulticloudjNamespaceable.trim("foo")
+                + "/" + AbstractBaseMulticloudjNamespaceable.NAMESPACE_IDENTIFIER;
+        assertTrue(MulticloudjUtils.doesObjectExist(bc, expectedMarkerKey),
+                "Namespace marker should exist at: " + expectedMarkerKey);
+    }
+
+    @Test
+    public void testCreate_isIdempotent() throws IOException {
+        BucketClient bc = InMemoryBucketClients.fresh();
+        Probe probe = new Probe(bc);
+
+        probe.create("idempotent-ns");
+        probe.create("idempotent-ns");
+
+        String markerKey = "cantor-test/" + AbstractBaseMulticloudjNamespaceable.trim("idempotent-ns")
+                + "/" + AbstractBaseMulticloudjNamespaceable.NAMESPACE_IDENTIFIER;
+        assertTrue(MulticloudjUtils.doesObjectExist(bc, markerKey),
+                "Marker should still exist after duplicate create");
+    }
+
+    @Test
+    public void testDrop_removesAllKeysUnderPrefix() throws IOException {
+        BucketClient bc = InMemoryBucketClients.fresh();
+        Probe probe = new Probe(bc);
+
+        probe.create("drop-ns");
+
+        String prefix = "cantor-test/" + AbstractBaseMulticloudjNamespaceable.trim("drop-ns");
+        for (int i = 0; i < 5; i++) {
+            MulticloudjUtils.upload(bc, prefix + "/extra-key-" + i,
+                    ("data-" + i).getBytes(StandardCharsets.UTF_8));
+        }
+
+        // 5 extra keys + 1 namespace marker = 6 total
+        assertEquals(MulticloudjUtils.countKeys(bc, prefix), 6);
+
+        probe.drop("drop-ns");
+
+        assertEquals(MulticloudjUtils.countKeys(bc, prefix), 0,
+                "All keys including the namespace marker should be deleted");
+    }
+
+    @Test
+    public void testTrim_lowercasesStripsAndAppendsHash() {
+        // Verify the output matches the cantor-s3 AbstractBaseS3Namespaceable.trim() exactly
+        String input = "My.NS/123";
+        String expected = String.format("%s-%s",
+                input.replaceAll("[^A-Za-z0-9_\\-/]", "").toLowerCase()
+                        .substring(0, Math.min(64, input.replaceAll("[^A-Za-z0-9_\\-/]", "").toLowerCase().length())),
+                Math.abs(input.hashCode()));
+        String actual = AbstractBaseMulticloudjNamespaceable.trim(input);
+        assertEquals(actual, expected,
+                "trim() output must be byte-identical to AbstractBaseS3Namespaceable.trim()");
+    }
+
+    @Test
+    public void testTrim_truncatesAt64Chars() {
+        // Input longer than 64 chars after stripping
+        String longInput = "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz01234567890";
+        String trimmed = AbstractBaseMulticloudjNamespaceable.trim(longInput);
+
+        // The format is: <cleanName up to 64 chars>-<abs(hashCode)>
+        String cleanName = longInput.replaceAll("[^A-Za-z0-9_\\-/]", "").toLowerCase();
+        String expectedPrefix = cleanName.substring(0, 64);
+        assertTrue(trimmed.startsWith(expectedPrefix),
+                "Trimmed name should start with the first 64 chars of the cleaned input");
+        assertTrue(trimmed.contains("-" + Math.abs(longInput.hashCode())),
+                "Trimmed name should end with the hash suffix");
+    }
+
+    @Test
+    public void testConstructor_rejectsNullBucketClient() {
+        assertThrows(IllegalArgumentException.class, () -> new Probe(null));
+    }
+
+    @Test
+    public void testTrim_stripsDisallowedCharacters() {
+        String trimmed = AbstractBaseMulticloudjNamespaceable.trim("Foo Bar!@#$%^&*()");
+        // After the strip and lowercase, only "foobar" remains (whitespace and symbols stripped)
+        // The format is "foobar-<abs(hashCode)>"
+        assertTrue(trimmed.startsWith("foobar-"),
+                "Disallowed characters should be stripped, got: " + trimmed);
+    }
+
+    @Test
+    public void testTrim_emptyNamespaceProducesHashOnly() {
+        String trimmed = AbstractBaseMulticloudjNamespaceable.trim("");
+        // After strip, cleanName is "" (length 0). Substring(0, 0) = "". Format becomes "-<abs(0)>" = "-0"
+        assertEquals(trimmed, "-0", "trim(\"\") should produce '-0'");
+    }
+}

--- a/cantor-multicloudj/src/test/java/com/salesforce/cantor/multicloudj/CantorOnMulticloudjTest.java
+++ b/cantor-multicloudj/src/test/java/com/salesforce/cantor/multicloudj/CantorOnMulticloudjTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2020, Salesforce.com, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.cantor.multicloudj;
+
+import com.salesforce.cantor.multicloudj.support.InMemoryBucketClients;
+import com.salesforce.multicloudj.blob.client.BucketClient;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static org.testng.Assert.*;
+
+public class CantorOnMulticloudjTest {
+
+    @Test
+    public void testObjects_returnsNonNull() throws Exception {
+        final BucketClient bc = InMemoryBucketClients.fresh();
+        try (CantorOnMulticloudj cantor = new CantorOnMulticloudj(bc)) {
+            assertNotNull(cantor.objects());
+            assertTrue(cantor.objects() instanceof ObjectsOnMulticloudj);
+        }
+    }
+
+    @Test
+    public void testEvents_returnsNonNull() throws Exception {
+        final BucketClient bc = InMemoryBucketClients.fresh();
+        try (CantorOnMulticloudj cantor = new CantorOnMulticloudj(bc)) {
+            assertNotNull(cantor.events());
+            assertTrue(cantor.events() instanceof EventsOnMulticloudj);
+        }
+    }
+
+    @Test
+    public void testSets_throwsUnsupportedOperation() throws Exception {
+        final BucketClient bc = InMemoryBucketClients.fresh();
+        try (CantorOnMulticloudj cantor = new CantorOnMulticloudj(bc)) {
+            try {
+                cantor.sets();
+                fail("Expected UnsupportedOperationException");
+            } catch (UnsupportedOperationException e) {
+                assertTrue(e.getMessage().contains("Sets are not implemented on multicloudj"),
+                        "Message should indicate Sets not implemented, got: " + e.getMessage());
+            }
+        }
+    }
+
+    @Test
+    public void testConvenienceConstructor_buildsInMemoryClient() throws Exception {
+        // The convenience constructor builds its own BucketClient internally
+        // Using "memory" provider which is already registered by InMemoryBucketClients seeding
+        final String bucket = "ctor-test-" + System.nanoTime();
+        InMemoryBucketClients.registerBucket(bucket);
+        try (CantorOnMulticloudj cantor = new CantorOnMulticloudj("memory", "any-region", bucket)) {
+            assertNotNull(cantor.objects());
+            assertNotNull(cantor.events());
+        }
+    }
+
+    @Test
+    public void testConvenienceConstructor_missingProviderThrowsIOException() {
+        try {
+            new CantorOnMulticloudj("this-provider-does-not-exist", "us-east-1", "some-bucket");
+            fail("Expected IOException for missing provider");
+        } catch (IOException e) {
+            assertTrue(e.getMessage().contains("failed to construct BucketClient"),
+                    "Message should mention 'failed to construct BucketClient', got: " + e.getMessage());
+            assertTrue(e.getMessage().contains("this-provider-does-not-exist"),
+                    "Message should contain provider id, got: " + e.getMessage());
+        }
+    }
+
+    @Test
+    public void testClose_externallyManagedClientNotClosed() throws Exception {
+        final BucketClient bc = InMemoryBucketClients.fresh();
+        CantorOnMulticloudj cantor = new CantorOnMulticloudj(bc);
+        cantor.close();
+
+        // After CantorOnMulticloudj.close(), the externally-managed client should still be usable
+        assertTrue(bc.doesBucketExist(),
+                "Externally-managed BucketClient should still work after CantorOnMulticloudj.close()");
+    }
+
+    @Test
+    public void testClose_isIdempotent() throws Exception {
+        final BucketClient bc = InMemoryBucketClients.fresh();
+        CantorOnMulticloudj cantor = new CantorOnMulticloudj(bc);
+        cantor.close();
+        cantor.close(); // second call must not throw
+    }
+
+    // ─── Negative input validation tests ─────────────────────────────────────────
+
+    @Test
+    public void testPrimaryConstructor_rejectsNullBucketClient() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new CantorOnMulticloudj((BucketClient) null));
+    }
+
+    @Test
+    public void testConvenienceConstructor_rejectsNullProviderId() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new CantorOnMulticloudj(null, "us-east-1", "bucket"));
+    }
+
+    @Test
+    public void testConvenienceConstructor_rejectsEmptyProviderId() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new CantorOnMulticloudj("", "us-east-1", "bucket"));
+    }
+
+    @Test
+    public void testConvenienceConstructor_rejectsNullRegion() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new CantorOnMulticloudj("memory", null, "bucket"));
+    }
+
+    @Test
+    public void testConvenienceConstructor_rejectsEmptyRegion() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new CantorOnMulticloudj("memory", "", "bucket"));
+    }
+
+    @Test
+    public void testConvenienceConstructor_rejectsNullBucket() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new CantorOnMulticloudj("memory", "us-east-1", null));
+    }
+
+    @Test
+    public void testConvenienceConstructor_rejectsEmptyBucket() {
+        assertThrows(IllegalArgumentException.class,
+                () -> new CantorOnMulticloudj("memory", "us-east-1", ""));
+    }
+}

--- a/cantor-multicloudj/src/test/java/com/salesforce/cantor/multicloudj/EventsOnMulticloudjTest.java
+++ b/cantor-multicloudj/src/test/java/com/salesforce/cantor/multicloudj/EventsOnMulticloudjTest.java
@@ -1,0 +1,389 @@
+/*
+ * Copyright (c) 2020, Salesforce.com, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.cantor.multicloudj;
+
+import com.salesforce.cantor.Cantor;
+import com.salesforce.cantor.Events;
+import com.salesforce.cantor.Objects;
+import com.salesforce.cantor.Sets;
+import com.salesforce.cantor.common.AbstractBaseEventsTest;
+import com.salesforce.cantor.multicloudj.support.InMemoryBucketClients;
+import com.salesforce.multicloudj.blob.client.BucketClient;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.*;
+import java.util.concurrent.*;
+
+import static org.testng.Assert.*;
+
+public class EventsOnMulticloudjTest extends AbstractBaseEventsTest {
+    private final Cantor cantor;
+    private final EventsOnMulticloudj eventsImpl;
+
+    public EventsOnMulticloudjTest() throws IOException {
+        BucketClient bc = InMemoryBucketClients.fresh();
+        this.eventsImpl = new EventsOnMulticloudj(bc, createTempBufferDir(), 1);
+        this.cantor = new TestCantor(bc, eventsImpl);
+    }
+
+    @Override
+    protected Cantor getCantor() throws IOException {
+        return cantor;
+    }
+
+    @Test
+    public void testGetMatchingKeys_rejectsStartAfterEnd() throws IOException {
+        final Events events = cantor.events();
+        final String ns = "reject-start-after-end-" + UUID.randomUUID();
+        events.create(ns);
+        assertThrows(IllegalArgumentException.class,
+                () -> events.get(ns, 20, 10, null, null));
+        events.drop(ns);
+    }
+
+    @Test
+    public void testIncludePayloads_roundTrips() throws IOException {
+        final Events events = cantor.events();
+        final String ns = "payload-roundtrip-" + UUID.randomUUID();
+        events.create(ns);
+
+        byte[] payload = "hello-payload-test".getBytes();
+        long ts = System.currentTimeMillis();
+        Map<String, String> meta = Collections.singletonMap("k", "v");
+        events.store(ns, ts, meta, null, payload);
+        eventsImpl.forceFlushNow();
+
+        List<Events.Event> results = events.get(ns, ts, ts + 1, true);
+        assertEquals(results.size(), 1);
+        assertEquals(results.get(0).getPayload(), payload);
+
+        events.drop(ns);
+    }
+
+    @Test
+    public void testTwoInstances_dontShareState() throws IOException {
+        Path bufferDir = createTempBufferDirPath();
+        BucketClient bc = InMemoryBucketClients.fresh();
+
+        EventsOnMulticloudj events1 = new EventsOnMulticloudj(bc, bufferDir.toString(), 60);
+        EventsOnMulticloudj events2 = new EventsOnMulticloudj(bc, bufferDir.toString(), 60);
+
+        String ns = "shared-test-ns-" + UUID.randomUUID();
+        events1.create(ns);
+
+        long ts = System.currentTimeMillis();
+        events1.store(ns, Collections.singleton(
+                new Events.Event(ts, Collections.singletonMap("source", "inst1"), null)));
+        events2.store(ns, Collections.singleton(
+                new Events.Event(ts + 1, Collections.singletonMap("source", "inst2"), null)));
+
+        events1.forceFlushNow();
+        events2.forceFlushNow();
+
+        List<Events.Event> all = events1.get(ns, ts, ts + 2, null, null, false, true, 0);
+        assertEquals(all.size(), 2);
+
+        events1.close();
+        events2.close();
+    }
+
+    @Test
+    public void testStore_concurrentWritesDifferentNamespaces() throws Exception {
+        BucketClient bc = InMemoryBucketClients.fresh();
+        EventsOnMulticloudj events = new EventsOnMulticloudj(bc, createTempBufferDir(), 60);
+
+        String ns1 = "concurrent-ns1-" + UUID.randomUUID();
+        String ns2 = "concurrent-ns2-" + UUID.randomUUID();
+        events.create(ns1);
+        events.create(ns2);
+
+        long ts = System.currentTimeMillis();
+        int count = 50;
+
+        ExecutorService executor = Executors.newFixedThreadPool(4);
+        List<Future<?>> futures = new ArrayList<>();
+
+        for (int i = 0; i < count; i++) {
+            final int idx = i;
+            futures.add(executor.submit(() -> {
+                try {
+                    events.store(ns1, Collections.singleton(
+                            new Events.Event(ts + idx, Collections.singletonMap("i", String.valueOf(idx)), null)));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }));
+            futures.add(executor.submit(() -> {
+                try {
+                    events.store(ns2, Collections.singleton(
+                            new Events.Event(ts + idx, Collections.singletonMap("i", String.valueOf(idx)), null)));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }));
+        }
+
+        for (Future<?> f : futures) {
+            f.get(30, TimeUnit.SECONDS);
+        }
+        executor.shutdown();
+
+        events.forceFlushNow();
+
+        List<Events.Event> results1 = events.get(ns1, ts, ts + count, null, null, false, true, 0);
+        List<Events.Event> results2 = events.get(ns2, ts, ts + count, null, null, false, true, 0);
+
+        assertEquals(results1.size(), count);
+        assertEquals(results2.size(), count);
+
+        events.close();
+    }
+
+    // ─── Constructor validation tests ────────────────────────────────────────────
+
+    @Test
+    public void testConstructor_rejectsZeroFlushInterval() {
+        BucketClient bc = InMemoryBucketClients.fresh();
+        assertThrows(IllegalArgumentException.class,
+                () -> new EventsOnMulticloudj(bc, createTempBufferDir(), 0));
+    }
+
+    @Test
+    public void testConstructor_rejectsNegativeFlushInterval() {
+        BucketClient bc = InMemoryBucketClients.fresh();
+        assertThrows(IllegalArgumentException.class,
+                () -> new EventsOnMulticloudj(bc, createTempBufferDir(), -1));
+    }
+
+    @Test
+    public void testConstructor_rejectsNullBufferDirectory() {
+        BucketClient bc = InMemoryBucketClients.fresh();
+        assertThrows(IllegalArgumentException.class,
+                () -> new EventsOnMulticloudj(bc, null, 60));
+    }
+
+    @Test
+    public void testConstructor_rejectsEmptyBufferDirectory() {
+        BucketClient bc = InMemoryBucketClients.fresh();
+        assertThrows(IllegalArgumentException.class,
+                () -> new EventsOnMulticloudj(bc, "", 60));
+    }
+
+    @Test
+    public void testGet_limitCapsResultSize() throws IOException {
+        final Events events = cantor.events();
+        final String ns = "limit-test-" + UUID.randomUUID();
+        events.create(ns);
+
+        long base = System.currentTimeMillis();
+        // Store 5 events at consecutive timestamps
+        for (int i = 0; i < 5; i++) {
+            events.store(ns, base + i, Collections.singletonMap("i", String.valueOf(i)), null);
+        }
+        eventsImpl.forceFlushNow();
+
+        List<Events.Event> capped = events.get(ns, base, base + 5, null, null, false, true, 3);
+        assertEquals(capped.size(), 3, "limit=3 should cap result set to 3 events");
+
+        events.drop(ns);
+    }
+
+    @Test
+    public void testGet_descendingOrder() throws IOException {
+        final Events events = cantor.events();
+        final String ns = "descending-test-" + UUID.randomUUID();
+        events.create(ns);
+
+        long base = System.currentTimeMillis();
+        for (int i = 0; i < 3; i++) {
+            events.store(ns, base + i, Collections.singletonMap("i", String.valueOf(i)), null);
+        }
+        eventsImpl.forceFlushNow();
+
+        List<Events.Event> descending = events.get(ns, base, base + 3, null, null, false, false, 0);
+        assertEquals(descending.size(), 3);
+        // Descending: newest first
+        assertTrue(descending.get(0).getTimestampMillis() >= descending.get(1).getTimestampMillis(),
+                "First result should have the largest timestamp");
+        assertTrue(descending.get(1).getTimestampMillis() >= descending.get(2).getTimestampMillis(),
+                "Results should be in descending order");
+
+        events.drop(ns);
+    }
+
+    @Test
+    public void testExpire_removesOldEvents() throws IOException {
+        final Events events = cantor.events();
+        final String ns = "expire-test-" + UUID.randomUUID();
+        events.create(ns);
+
+        long now = System.currentTimeMillis();
+        long old = now - TimeUnit.HOURS.toMillis(2);
+
+        events.store(ns, old, Collections.singletonMap("age", "old"), null);
+        events.store(ns, now, Collections.singletonMap("age", "new"), null);
+        eventsImpl.forceFlushNow();
+
+        events.expire(ns, now - TimeUnit.HOURS.toMillis(1));
+
+        List<Events.Event> remaining = events.get(ns, old, now + 1, null, null);
+        assertEquals(remaining.size(), 1);
+        assertEquals(remaining.get(0).getMetadata().get("age"), "new");
+
+        events.drop(ns);
+    }
+
+    // ─── F2: restrictive buffer-directory permissions (CWE-276/200) ──────────────
+
+    @Test
+    public void testBufferDirectory_createdWithPosix700Permissions() throws IOException {
+        // Skip on non-POSIX filesystems (e.g. Windows). On macOS/Linux, verify 700.
+        if (!FileSystems.getDefault().supportedFileAttributeViews().contains("posix")) {
+            return;
+        }
+
+        // Create a parent that is deliberately *broader* than 700 (755) so we can prove
+        // the constructor explicitly tightens the per-instance buffer root regardless of
+        // the parent's mode.
+        Path parent = Files.createTempDirectory("cantor-events-f2-parent-");
+        Files.setPosixFilePermissions(parent, PosixFilePermissions.fromString("rwxr-xr-x"));
+
+        BucketClient bc = InMemoryBucketClients.fresh();
+        try (EventsOnMulticloudj events = new EventsOnMulticloudj(bc, parent.toString(), 60)) {
+            // The constructor creates exactly one per-instance subdirectory under `parent`
+            // named with the instance UUID; assert that subdir has 700 perms.
+            try (java.util.stream.Stream<Path> children = Files.list(parent)) {
+                List<Path> instanceDirs = children.filter(Files::isDirectory)
+                        .collect(java.util.stream.Collectors.toList());
+                assertEquals(instanceDirs.size(), 1, "Expected exactly one per-instance buffer subdir");
+                Set<PosixFilePermission> perms = Files.getPosixFilePermissions(instanceDirs.get(0));
+                Set<PosixFilePermission> expected = new HashSet<>(Arrays.asList(
+                        PosixFilePermission.OWNER_READ,
+                        PosixFilePermission.OWNER_WRITE,
+                        PosixFilePermission.OWNER_EXECUTE));
+                assertEquals(perms, expected,
+                        "Per-instance buffer subdir should be created with 700 permissions on POSIX systems");
+            }
+        }
+    }
+
+    // ─── F4: expire() must flushBeforeRead so buffered events get expired ────────
+
+    @Test
+    public void testExpire_flushesBufferedEventsBeforeExpiry() throws IOException {
+        // R-D: prior to the fix, expire() didn't call flushBeforeRead(), so events still
+        // sitting in the in-memory buffer survived the expiry call and reappeared on later
+        // reads. Use a long flush interval so the scheduled flusher is guaranteed NOT to
+        // run during the test — the only way these events make it to storage (and are then
+        // subject to deletion by expire()) is if expire() itself flushes first.
+        BucketClient bc = InMemoryBucketClients.fresh();
+        try (EventsOnMulticloudj events = new EventsOnMulticloudj(bc, createTempBufferDir(), 3600)) {
+            String ns = "f4-expire-flushes-" + UUID.randomUUID();
+            events.create(ns);
+
+            long now = System.currentTimeMillis();
+            long old = now - TimeUnit.HOURS.toMillis(2);
+
+            // Two events in the past, still sitting in the buffer (no forceFlushNow).
+            events.store(ns, old, Collections.singletonMap("age", "old-1"), null);
+            events.store(ns, old + 1, Collections.singletonMap("age", "old-2"), null);
+
+            // expire everything older than 1 hour ago - must flush first, then delete.
+            events.expire(ns, now - TimeUnit.HOURS.toMillis(1));
+
+            List<Events.Event> remaining = events.get(ns, old, now + 1, null, null);
+            assertEquals(remaining.size(), 0,
+                    "Buffered events within expiry window should be flushed and then deleted by expire()");
+
+            events.drop(ns);
+        }
+    }
+
+    // ─── F3: validate and canonicalize buffer directory path (CWE-22) ────────────
+
+    @Test
+    public void testConstructor_rejectsDotDotInBufferPath() {
+        BucketClient bc = InMemoryBucketClients.fresh();
+        assertThrows(IllegalArgumentException.class,
+                () -> new EventsOnMulticloudj(bc, "../../etc/cantor-buf", 60));
+    }
+
+    @Test
+    public void testConstructor_rejectsDotDotMiddleSegment() {
+        BucketClient bc = InMemoryBucketClients.fresh();
+        assertThrows(IllegalArgumentException.class,
+                () -> new EventsOnMulticloudj(bc, "/tmp/../etc/cantor-buf", 60));
+    }
+
+    @Test
+    public void testConstructor_rejectsExistingNonDirectoryPath() throws IOException {
+        // Create a regular file and pass it as buffer "dir" — should be rejected.
+        Path tmpFile = Files.createTempFile("cantor-events-multicloudj-test-not-a-dir", ".txt");
+        try {
+            BucketClient bc = InMemoryBucketClients.fresh();
+            assertThrows(IllegalArgumentException.class,
+                    () -> new EventsOnMulticloudj(bc, tmpFile.toString(), 60));
+        } finally {
+            Files.deleteIfExists(tmpFile);
+        }
+    }
+
+    @Test
+    public void testConstructor_acceptsAbsoluteCleanPath() throws IOException {
+        Path bufferDir = createTempBufferDirPath();
+        BucketClient bc = InMemoryBucketClients.fresh();
+        try (EventsOnMulticloudj events = new EventsOnMulticloudj(bc, bufferDir.toString(), 60)) {
+            // Constructor must succeed for a clean absolute path.
+            assertTrue(Files.isDirectory(bufferDir));
+        }
+    }
+
+    private static String createTempBufferDir() {
+        return createTempBufferDirPath().toString();
+    }
+
+    private static Path createTempBufferDirPath() {
+        try {
+            return Files.createTempDirectory("cantor-events-multicloudj-test-");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static final class TestCantor implements Cantor {
+        private final EventsOnMulticloudj events;
+        private final ObjectsOnMulticloudj objects;
+
+        TestCantor(BucketClient bucketClient, EventsOnMulticloudj events) throws IOException {
+            this.events = events;
+            this.objects = new ObjectsOnMulticloudj(bucketClient);
+        }
+
+        @Override
+        public Objects objects() {
+            return objects;
+        }
+
+        @Override
+        public Sets sets() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Events events() {
+            return events;
+        }
+    }
+}

--- a/cantor-multicloudj/src/test/java/com/salesforce/cantor/multicloudj/MulticloudjUtilsTest.java
+++ b/cantor-multicloudj/src/test/java/com/salesforce/cantor/multicloudj/MulticloudjUtilsTest.java
@@ -1,0 +1,423 @@
+/*
+ * Copyright (c) 2020, Salesforce.com, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.cantor.multicloudj;
+
+import com.salesforce.multicloudj.blob.client.BucketClient;
+import com.salesforce.multicloudj.blob.driver.BlobInfo;
+import com.salesforce.cantor.multicloudj.support.InMemoryBucketClients;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+import static org.testng.Assert.*;
+
+public class MulticloudjUtilsTest {
+
+    // ─── matchesMetadata tests ───────────────────────────────────────────────────
+
+    @DataProvider(name = "metadataMatchCases")
+    public Object[][] metadataMatchCases() {
+        return new Object[][] {
+            // { metadata map, query map, expected result }
+            // empty query matches everything
+            { Map.of("host", "web-01"), Collections.emptyMap(), true },
+            // implicit equality (no prefix)
+            { Map.of("host", "web-01"), Map.of("host", "web-01"), true },
+            // implicit equality miss
+            { Map.of("host", "web-01"), Map.of("host", "web-02"), false },
+            // explicit = operator
+            { Map.of("env", "prod"), Map.of("env", "=prod"), true },
+            // != operator
+            { Map.of("env", "prod"), Map.of("env", "!=staging"), true },
+            // != operator miss (value equals)
+            { Map.of("env", "prod"), Map.of("env", "!=prod"), false },
+            // ~ (LIKE) with trailing wildcard
+            { Map.of("host", "web-01"), Map.of("host", "~web*"), true },
+            // ~ (LIKE) with leading wildcard
+            { Map.of("host", "web-01"), Map.of("host", "~*-01"), true },
+            // ~ (LIKE) miss
+            { Map.of("host", "web-01"), Map.of("host", "~api*"), false },
+            // !~ (NOT LIKE)
+            { Map.of("host", "web-01"), Map.of("host", "!~api*"), true },
+            // !~ miss (pattern matches)
+            { Map.of("host", "web-01"), Map.of("host", "!~web*"), false },
+            // multi-key AND: both match
+            { Map.of("host", "web-01", "env", "prod"), Map.of("host", "web-01", "env", "prod"), true },
+            // multi-key AND: one misses
+            { Map.of("host", "web-01", "env", "prod"), Map.of("host", "web-01", "env", "staging"), false },
+            // query key not in metadata
+            { Map.of("host", "web-01"), Map.of("region", "us-west"), false },
+        };
+    }
+
+    @Test(dataProvider = "metadataMatchCases")
+    public void testMatchesMetadata(Map<String, String> metadata, Map<String, String> query, boolean expected) {
+        assertEquals(MulticloudjUtils.matchesMetadata(metadata, query), expected);
+    }
+
+    // ─── matchesDimensions tests ─────────────────────────────────────────────────
+
+    @DataProvider(name = "dimensionMatchCases")
+    public Object[][] dimensionMatchCases() {
+        return new Object[][] {
+            // { dimensions map, query map, expected result }
+            // empty query matches everything
+            { Map.of("cpu", 0.5), Collections.emptyMap(), true },
+            // implicit equality
+            { Map.of("cpu", 0.5), Map.of("cpu", "0.5"), true },
+            // implicit equality miss
+            { Map.of("cpu", 0.5), Map.of("cpu", "0.6"), false },
+            // explicit = operator
+            { Map.of("cpu", 42.0), Map.of("cpu", "=42.0"), true },
+            // != operator
+            { Map.of("cpu", 42.0), Map.of("cpu", "!=43.0"), true },
+            // != operator miss
+            { Map.of("cpu", 42.0), Map.of("cpu", "!=42.0"), false },
+            // > operator
+            { Map.of("cpu", 0.8), Map.of("cpu", ">0.5"), true },
+            // > operator miss (equal)
+            { Map.of("cpu", 0.5), Map.of("cpu", ">0.5"), false },
+            // >= operator
+            { Map.of("cpu", 0.5), Map.of("cpu", ">=0.5"), true },
+            // < operator
+            { Map.of("cpu", 0.3), Map.of("cpu", "<0.5"), true },
+            // < operator miss
+            { Map.of("cpu", 0.5), Map.of("cpu", "<0.5"), false },
+            // <= operator
+            { Map.of("cpu", 0.5), Map.of("cpu", "<=0.5"), true },
+            // .. (BETWEEN inclusive)
+            { Map.of("cpu", 0.5), Map.of("cpu", "0.0..1.0"), true },
+            // .. at boundaries
+            { Map.of("cpu", 0.0), Map.of("cpu", "0.0..1.0"), true },
+            { Map.of("cpu", 1.0), Map.of("cpu", "0.0..1.0"), true },
+            // .. miss (out of range)
+            { Map.of("cpu", 1.5), Map.of("cpu", "0.0..1.0"), false },
+            // multi-key AND: both match
+            { Map.of("cpu", 0.5, "mem", 1024.0), Map.of("cpu", ">=0.0", "mem", "<=2048.0"), true },
+            // multi-key AND: one misses
+            { Map.of("cpu", 0.5, "mem", 4096.0), Map.of("cpu", ">=0.0", "mem", "<=2048.0"), false },
+            // query key not in dimensions
+            { Map.of("cpu", 0.5), Map.of("disk", ">0.0"), false },
+        };
+    }
+
+    @Test(dataProvider = "dimensionMatchCases")
+    public void testMatchesDimensions(Map<String, Double> dimensions, Map<String, String> query, boolean expected) {
+        assertEquals(MulticloudjUtils.matchesDimensions(dimensions, query), expected);
+    }
+
+    // ─── listKeysOrdered tests ───────────────────────────────────────────────────
+
+    @Test
+    public void listKeysOrdered_pagination_returnsStableOrder() throws IOException {
+        final BucketClient bc = InMemoryBucketClients.fresh();
+        final String prefix = "test-prefix/";
+        final int totalKeys = 1000;
+
+        for (int i = 0; i < totalKeys; i++) {
+            String key = prefix + String.format("key-%04d", i);
+            MulticloudjUtils.upload(bc, key, "v".getBytes(StandardCharsets.UTF_8));
+        }
+
+        final Set<String> allCollected = new LinkedHashSet<>();
+        int pageSize = 100;
+        for (int start = 0; start < totalKeys; start += pageSize) {
+            List<String> page = MulticloudjUtils.listKeysOrdered(bc, prefix, start, pageSize);
+            for (String key : page) {
+                boolean added = allCollected.add(key);
+                assertTrue(added, "Duplicate key found in pagination: " + key);
+            }
+        }
+
+        assertEquals(allCollected.size(), totalKeys, "Expected all keys to be paged through without gaps");
+    }
+
+    @Test
+    public void listKeysOrdered_countMinusOne_returnsAll() throws IOException {
+        final BucketClient bc = InMemoryBucketClients.fresh();
+        final String prefix = "all-keys/";
+        final int totalKeys = 50;
+
+        for (int i = 0; i < totalKeys; i++) {
+            String key = prefix + String.format("key-%03d", i);
+            MulticloudjUtils.upload(bc, key, "x".getBytes(StandardCharsets.UTF_8));
+        }
+
+        List<String> result = MulticloudjUtils.listKeysOrdered(bc, prefix, 0, -1);
+        assertEquals(result.size(), totalKeys, "count=-1 should return all keys");
+    }
+
+    // ─── getMatchingKeys tests ───────────────────────────────────────────────────
+
+    @Test
+    public void getMatchingKeys_minimalPrefixCover() throws IOException {
+        final BucketClient bc = InMemoryBucketClients.fresh();
+        final String namespaceKeyPrefix = "cantor-events/test-ns";
+
+        // Window spanning 2 hours should produce hour-level prefixes
+        long startMs = 1700000000000L; // 2023-11-14T22:13:20Z
+        long endMs = startMs + TimeUnit.HOURS.toMillis(2); // +2 hours
+
+        Set<String> prefixes = MulticloudjUtils.getMatchingKeys(bc, namespaceKeyPrefix, startMs, endMs);
+
+        assertNotNull(prefixes);
+        assertFalse(prefixes.isEmpty(), "Should produce at least one prefix");
+
+        // All prefixes should start with the namespace key prefix
+        for (String p : prefixes) {
+            assertTrue(p.startsWith(namespaceKeyPrefix + "/"),
+                    "Prefix should start with namespace key prefix: " + p);
+        }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void getMatchingKeys_rejectsStartAfterEnd() throws IOException {
+        final BucketClient bc = InMemoryBucketClients.fresh();
+        MulticloudjUtils.getMatchingKeys(bc, "cantor-events/ns", 2000L, 1000L);
+    }
+
+    // ─── deleteAllUnderPrefix / deleteBatched tests ──────────────────────────────
+
+    @Test
+    public void deleteBatched_removesAllKeys() throws IOException {
+        final BucketClient bc = InMemoryBucketClients.fresh();
+        final String prefix = "delete-test/";
+        final int totalKeys = 250;
+
+        for (int i = 0; i < totalKeys; i++) {
+            String key = prefix + String.format("key-%03d", i);
+            MulticloudjUtils.upload(bc, key, "data".getBytes(StandardCharsets.UTF_8));
+        }
+
+        assertEquals(MulticloudjUtils.countKeys(bc, prefix), totalKeys);
+
+        MulticloudjUtils.deleteAllUnderPrefix(bc, prefix);
+
+        assertEquals(MulticloudjUtils.countKeys(bc, prefix), 0, "All keys should be deleted");
+    }
+
+    // ─── wrapAsIOException tests ─────────────────────────────────────────────────
+
+    @Test
+    public void wrapAsIOException_includesOpAndNamespace() {
+        RuntimeException cause = new RuntimeException("network error");
+        IOException wrapped = MulticloudjUtils.wrapAsIOException("store", "my-namespace", cause);
+
+        assertNotNull(wrapped);
+        assertTrue(wrapped.getMessage().contains("store"), "Should include the operation name");
+        assertTrue(wrapped.getMessage().contains("my-namespace"), "Should include the namespace");
+        assertEquals(wrapped.getCause(), cause, "Should preserve the original cause");
+    }
+
+    // ─── doesObjectExist tests ───────────────────────────────────────────────────
+
+    @Test
+    public void doesObjectExist_returnsFalseForMissing() throws IOException {
+        final BucketClient bc = InMemoryBucketClients.fresh();
+        assertFalse(MulticloudjUtils.doesObjectExist(bc, "nonexistent-key"));
+    }
+
+    @Test
+    public void doesObjectExist_returnsTrueAfterUpload() throws IOException {
+        final BucketClient bc = InMemoryBucketClients.fresh();
+        MulticloudjUtils.upload(bc, "exists-key", "hello".getBytes(StandardCharsets.UTF_8));
+        assertTrue(MulticloudjUtils.doesObjectExist(bc, "exists-key"));
+    }
+
+    // ─── upload / download round-trip tests ──────────────────────────────────────
+
+    @Test
+    public void uploadAndDownload_roundTrip() throws IOException {
+        final BucketClient bc = InMemoryBucketClients.fresh();
+        byte[] data = "hello world".getBytes(StandardCharsets.UTF_8);
+        String key = "round-trip/obj1";
+
+        MulticloudjUtils.upload(bc, key, data);
+        byte[] downloaded = MulticloudjUtils.download(bc, key);
+
+        assertEquals(downloaded, data);
+    }
+
+    // ─── countKeys tests ─────────────────────────────────────────────────────────
+
+    @Test
+    public void countKeys_emptyPrefix() throws IOException {
+        final BucketClient bc = InMemoryBucketClients.fresh();
+        assertEquals(MulticloudjUtils.countKeys(bc, "empty-prefix/"), 0);
+    }
+
+    @Test
+    public void countKeys_afterUploads() throws IOException {
+        final BucketClient bc = InMemoryBucketClients.fresh();
+        String prefix = "count-test/";
+
+        MulticloudjUtils.upload(bc, prefix + "a", "1".getBytes(StandardCharsets.UTF_8));
+        MulticloudjUtils.upload(bc, prefix + "b", "2".getBytes(StandardCharsets.UTF_8));
+        MulticloudjUtils.upload(bc, prefix + "c", "3".getBytes(StandardCharsets.UTF_8));
+
+        assertEquals(MulticloudjUtils.countKeys(bc, prefix), 3);
+    }
+
+    // ─── downloadRange tests ─────────────────────────────────────────────────────
+
+    @Test
+    public void downloadRange_returnsByteSubrange() throws IOException {
+        final BucketClient bc = InMemoryBucketClients.fresh();
+        byte[] data = "0123456789ABCDEFGHIJ".getBytes(StandardCharsets.UTF_8);
+        String key = "range-test/full";
+
+        MulticloudjUtils.upload(bc, key, data);
+
+        // The blob-inmemory provider may or may not natively support ranges. Either way,
+        // MulticloudjUtils.downloadRange falls back to a slice and must return the correct
+        // contiguous subrange [5, 9] = "56789".
+        byte[] slice = MulticloudjUtils.downloadRange(bc, key, 5, 9);
+        assertEquals(new String(slice, StandardCharsets.UTF_8), "56789");
+    }
+
+    @Test
+    public void downloadRange_offsetZero_returnsFromStart() throws IOException {
+        final BucketClient bc = InMemoryBucketClients.fresh();
+        byte[] data = "abcdef".getBytes(StandardCharsets.UTF_8);
+        MulticloudjUtils.upload(bc, "range-zero/k", data);
+
+        byte[] slice = MulticloudjUtils.downloadRange(bc, "range-zero/k", 0, 2);
+        assertEquals(new String(slice, StandardCharsets.UTF_8), "abc");
+    }
+
+    // ─── deleteBatched edge-case tests ───────────────────────────────────────────
+
+    @Test
+    public void deleteBatched_emptyCollection_isNoOp() throws IOException {
+        final BucketClient bc = InMemoryBucketClients.fresh();
+        // Should not throw for an empty collection.
+        MulticloudjUtils.deleteBatched(bc, Collections.emptyList());
+    }
+
+    @Test
+    public void deleteBatched_nullCollection_isNoOp() throws IOException {
+        final BucketClient bc = InMemoryBucketClients.fresh();
+        // Should not throw for null - documented no-op behavior.
+        MulticloudjUtils.deleteBatched(bc, null);
+    }
+
+    // ─── matchesMetadata / matchesDimensions null-handling tests ─────────────────
+
+    @Test
+    public void matchesMetadata_nullQueryMatchesAnything() {
+        assertTrue(MulticloudjUtils.matchesMetadata(Map.of("host", "web-01"), null));
+    }
+
+    @Test
+    public void matchesMetadata_nullMetadataWithNonEmptyQuery_returnsFalse() {
+        // metadata=null, query non-empty: a query expects a key that doesn't exist - should not match
+        assertFalse(MulticloudjUtils.matchesMetadata(null, Map.of("host", "web-01")));
+    }
+
+    @Test
+    public void matchesDimensions_nullQueryMatchesAnything() {
+        assertTrue(MulticloudjUtils.matchesDimensions(Map.of("cpu", 0.5), null));
+    }
+
+    @Test
+    public void matchesDimensions_nullDimensionsWithNonEmptyQuery_returnsFalse() {
+        assertFalse(MulticloudjUtils.matchesDimensions(null, Map.of("cpu", "0.5")));
+    }
+
+    // ─── getMatchingKeys edge cases ──────────────────────────────────────────────
+
+    @Test
+    public void getMatchingKeys_startEqualsEnd_producesAtLeastOnePrefix() throws IOException {
+        final BucketClient bc = InMemoryBucketClients.fresh();
+        long ts = 1700000000000L;
+        Set<String> prefixes = MulticloudjUtils.getMatchingKeys(bc, "cantor-events/ns", ts, ts);
+        assertNotNull(prefixes);
+        assertFalse(prefixes.isEmpty(), "start==end should still produce at least the boundary minute prefix");
+    }
+
+    // ─── max-download-size guard tests (F1: OOM prevention) ─────────────────────
+
+    @Test
+    public void download_throwsWhenBlobExceedsMaxDownloadSize() throws IOException {
+        final BucketClient bc = InMemoryBucketClients.fresh();
+        final String key = "oversized/blob";
+        // Upload a 1 KiB blob.
+        byte[] data = new byte[1024];
+        Arrays.fill(data, (byte) 'x');
+        MulticloudjUtils.upload(bc, key, data);
+
+        final long original = MulticloudjUtils.getMaxDownloadSizeBytes();
+        try {
+            // Configure the max to a value smaller than the blob we just uploaded.
+            MulticloudjUtils.setMaxDownloadSizeBytes(512);
+
+            IOException ioe = expectThrows(IOException.class, () -> MulticloudjUtils.download(bc, key));
+            assertTrue(ioe.getMessage() != null
+                            && ioe.getMessage().toLowerCase().contains("exceeds maximum download size"),
+                    "Exception message should mention exceeding max download size; got: " + ioe.getMessage());
+        } finally {
+            MulticloudjUtils.setMaxDownloadSizeBytes(original);
+        }
+    }
+
+    @Test
+    public void download_succeedsWhenBlobUnderMaxDownloadSize() throws IOException {
+        final BucketClient bc = InMemoryBucketClients.fresh();
+        final String key = "ok/blob";
+        byte[] data = "small payload".getBytes(StandardCharsets.UTF_8);
+        MulticloudjUtils.upload(bc, key, data);
+
+        final long original = MulticloudjUtils.getMaxDownloadSizeBytes();
+        try {
+            MulticloudjUtils.setMaxDownloadSizeBytes(1024L * 1024L); // 1 MiB
+            byte[] downloaded = MulticloudjUtils.download(bc, key);
+            assertEquals(downloaded, data);
+        } finally {
+            MulticloudjUtils.setMaxDownloadSizeBytes(original);
+        }
+    }
+
+    @Test
+    public void setMaxDownloadSizeBytes_rejectsNonPositive() {
+        final long original = MulticloudjUtils.getMaxDownloadSizeBytes();
+        try {
+            assertThrows(IllegalArgumentException.class,
+                    () -> MulticloudjUtils.setMaxDownloadSizeBytes(0));
+            assertThrows(IllegalArgumentException.class,
+                    () -> MulticloudjUtils.setMaxDownloadSizeBytes(-1));
+        } finally {
+            MulticloudjUtils.setMaxDownloadSizeBytes(original);
+        }
+    }
+
+    // ─── deleteBatched large-batch test (verifies chunking) ──────────────────────
+
+    @Test
+    public void deleteBatched_largerThanBatchMax_deletesAll() throws IOException {
+        final BucketClient bc = InMemoryBucketClients.fresh();
+        final String prefix = "large-delete/";
+        // 250 > DELETE_BATCH_MAX (100), forcing 3 batches
+        final int total = 250;
+        List<String> keys = new ArrayList<>();
+        for (int i = 0; i < total; i++) {
+            String key = prefix + String.format("k-%04d", i);
+            MulticloudjUtils.upload(bc, key, "x".getBytes(StandardCharsets.UTF_8));
+            keys.add(key);
+        }
+        assertEquals(MulticloudjUtils.countKeys(bc, prefix), total);
+
+        MulticloudjUtils.deleteBatched(bc, keys);
+
+        assertEquals(MulticloudjUtils.countKeys(bc, prefix), 0,
+                "All keys across multiple batches should be deleted");
+    }
+}

--- a/cantor-multicloudj/src/test/java/com/salesforce/cantor/multicloudj/ObjectsOnMulticloudjTest.java
+++ b/cantor-multicloudj/src/test/java/com/salesforce/cantor/multicloudj/ObjectsOnMulticloudjTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2020, Salesforce.com, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.cantor.multicloudj;
+
+import com.salesforce.cantor.Cantor;
+import com.salesforce.cantor.common.AbstractBaseObjectsTest;
+import com.salesforce.cantor.multicloudj.support.InMemoryBucketClients;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+import java.util.UUID;
+
+import static org.testng.Assert.*;
+
+public class ObjectsOnMulticloudjTest extends AbstractBaseObjectsTest {
+    private final Cantor cantor;
+
+    public ObjectsOnMulticloudjTest() throws IOException {
+        this.cantor = new CantorOnMulticloudj(InMemoryBucketClients.fresh());
+    }
+
+    @Override
+    protected Cantor getCantor() throws IOException {
+        return cantor;
+    }
+
+    @Test
+    public void testDelete_returnsFalseWhenAbsent() throws IOException {
+        final ObjectsOnMulticloudj objects = new ObjectsOnMulticloudj(InMemoryBucketClients.fresh());
+        final String ns = "delete-absent-ns-" + UUID.randomUUID();
+        objects.create(ns);
+        assertFalse(objects.delete(ns, "missing-key"));
+    }
+
+    @Test
+    public void testKeys_filtersOutNamespaceMarker() throws IOException {
+        final ObjectsOnMulticloudj objects = new ObjectsOnMulticloudj(InMemoryBucketClients.fresh());
+        final String ns = "marker-ns-" + UUID.randomUUID();
+        objects.create(ns);
+        objects.store(ns, "real-key", "data".getBytes());
+
+        Collection<String> keys = objects.keys(ns, "", 0, -1);
+        assertFalse(keys.contains(".namespace"), "keys() should filter out the .namespace marker");
+        assertTrue(keys.contains("real-key"), "keys() should include real keys");
+        assertEquals(keys.size(), 1);
+    }
+
+    @Test
+    public void testStore_propagatesIOExceptionForUncreatedNamespace() throws IOException {
+        final ObjectsOnMulticloudj objects = new ObjectsOnMulticloudj(InMemoryBucketClients.fresh());
+        final String uncreatedNs = "never-created-" + UUID.randomUUID();
+        assertThrows(IOException.class, () -> objects.store(uncreatedNs, "key", "val".getBytes()));
+    }
+
+    @Test
+    public void testStreamStore_roundTrip() throws IOException {
+        final ObjectsOnMulticloudj objects = new ObjectsOnMulticloudj(InMemoryBucketClients.fresh());
+        final String ns = "stream-ns-" + UUID.randomUUID();
+        objects.create(ns);
+
+        byte[] data = "streaming-content-hello".getBytes();
+        objects.store(ns, "stream-key", new ByteArrayInputStream(data), data.length);
+
+        InputStream result = objects.stream(ns, "stream-key");
+        assertNotNull(result, "stream() should return non-null for existing key");
+        byte[] read = result.readAllBytes();
+        assertEquals(read, data);
+    }
+
+    @Test
+    public void testStream_returnsNullForMissingKey() throws IOException {
+        final ObjectsOnMulticloudj objects = new ObjectsOnMulticloudj(InMemoryBucketClients.fresh());
+        final String ns = "stream-miss-ns-" + UUID.randomUUID();
+        objects.create(ns);
+
+        InputStream result = objects.stream(ns, "nonexistent-key");
+        assertNull(result, "stream() should return null when key does not exist");
+    }
+
+    @Test
+    public void testSize_excludesNamespaceMarker() throws IOException {
+        final ObjectsOnMulticloudj objects = new ObjectsOnMulticloudj(InMemoryBucketClients.fresh());
+        final String ns = "size-ns-" + UUID.randomUUID();
+        objects.create(ns);
+
+        assertEquals(objects.size(ns), 0, "Size should be 0 after create (marker excluded)");
+
+        objects.store(ns, "k1", "v1".getBytes());
+        objects.store(ns, "k2", "v2".getBytes());
+        assertEquals(objects.size(ns), 2);
+    }
+
+}

--- a/cantor-multicloudj/src/test/java/com/salesforce/cantor/multicloudj/support/InMemoryBucketClients.java
+++ b/cantor-multicloudj/src/test/java/com/salesforce/cantor/multicloudj/support/InMemoryBucketClients.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2020, Salesforce.com, Inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+ */
+
+package com.salesforce.cantor.multicloudj.support;
+
+import com.salesforce.multicloudj.blob.client.BucketClient;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Test-only factory that returns a {@link BucketClient} backed by the multicloudj
+ * in-memory blob provider.
+ *
+ * <p>The in-memory provider has a static {@code BUCKETS} map and requires the
+ * bucket to be registered before any operation. Because the supplied
+ * {@code BlobClient} would attempt to load every {@code AbstractBlobClient}
+ * service on the classpath (including blob-aws/blob-gcp/blob-ali, which lack
+ * public no-arg constructors and would explode under SPI lookup), this helper
+ * seeds the bucket directly via reflection on {@code InMemoryBlobStore.BUCKETS}.
+ *
+ * <p>Reflection on a SPI-internal field is brittle by design — this is a
+ * deliberate test-only hack. Production code never uses the in-memory provider.
+ */
+public final class InMemoryBucketClients {
+    private static final String IN_MEMORY_STORE_FQN =
+            "com.salesforce.multicloudj.blob.inmemory.InMemoryBlobStore";
+    private static final String BUCKET_METADATA_FQN =
+            "com.salesforce.multicloudj.blob.inmemory.InMemoryBlobStore$BucketMetadata";
+
+    private InMemoryBucketClients() {}
+
+    public static BucketClient fresh() {
+        String bucketName = "test-" + UUID.randomUUID();
+        registerBucket(bucketName);
+        return BucketClient.builder("memory")
+                .withBucket(bucketName)
+                .build();
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static void registerBucket(String bucketName) {
+        try {
+            Class<?> storeClass = Class.forName(IN_MEMORY_STORE_FQN);
+            Field bucketsField = storeClass.getDeclaredField("BUCKETS");
+            bucketsField.setAccessible(true);
+            Map buckets = (Map) bucketsField.get(null);
+
+            Class<?> metadataClass = Class.forName(BUCKET_METADATA_FQN);
+            Constructor<?> ctor = metadataClass.getDeclaredConstructor(Instant.class);
+            ctor.setAccessible(true);
+            Object metadata = ctor.newInstance(Instant.now());
+
+            buckets.put(bucketName, metadata);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(
+                    "Failed to seed in-memory bucket '" + bucketName + "'. "
+                            + "The multicloudj blob-inmemory layout may have changed; "
+                            + "verify InMemoryBlobStore.BUCKETS and BucketMetadata(Instant) still exist.",
+                    e);
+        }
+    }
+}

--- a/cantor-multicloudj/src/test/resources/logback-test.xml
+++ b/cantor-multicloudj/src/test/resources/logback-test.xml
@@ -1,0 +1,18 @@
+<!--
+  ~ Copyright (c) 2020, Salesforce.com, Inc.
+  ~ All rights reserved.
+  ~ SPDX-License-Identifier: BSD-3-Clause
+  ~ For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/BSD-3-Clause
+  -->
+
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%date{YYYY-MM-dd HH:mm:ss} %level [%thread] %logger{10} [%file:%line] %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/cantor-server/pom.xml
+++ b/cantor-server/pom.xml
@@ -69,6 +69,34 @@
             <artifactId>cantor-s3</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!--CANTOR MULTICLOUDJ-->
+        <dependency>
+            <groupId>com.salesforce.cantor</groupId>
+            <artifactId>cantor-multicloudj</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!--MULTICLOUDJ PROVIDER RUNTIMES (optional; deployers choose which cloud)-->
+        <dependency>
+            <groupId>com.salesforce.multicloudj</groupId>
+            <artifactId>blob-aws</artifactId>
+            <version>0.4.0</version>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.salesforce.multicloudj</groupId>
+            <artifactId>blob-ali</artifactId>
+            <version>0.4.0</version>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.salesforce.multicloudj</groupId>
+            <artifactId>blob-gcp</artifactId>
+            <version>0.4.0</version>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
         <!--CANTOR MISC-->
         <dependency>
             <groupId>com.salesforce.cantor</groupId>

--- a/cantor-server/src/main/java/com/salesforce/cantor/server/Constants.java
+++ b/cantor-server/src/main/java/com/salesforce/cantor/server/Constants.java
@@ -40,4 +40,14 @@ public class Constants {
     public static final String CANTOR_S3_PROXY_PORT = "proxy.port";
     public static final String CANTOR_S3_ENDPOINT_OVERRIDE = "endpoint.override";
     public static final String CANTOR_S3_SETS_TYPE = "sets.type";
+
+    // multicloudj configuration
+    public static final String CANTOR_MULTICLOUDJ_PROVIDER = "provider";
+    public static final String CANTOR_MULTICLOUDJ_BUCKET_NAME = "bucket";
+    public static final String CANTOR_MULTICLOUDJ_BUCKET_REGION = "region";
+    public static final String CANTOR_MULTICLOUDJ_PROXY_HOST = "proxy.host";
+    public static final String CANTOR_MULTICLOUDJ_PROXY_PORT = "proxy.port";
+    public static final String CANTOR_MULTICLOUDJ_ENDPOINT_OVERRIDE = "endpoint.override";
+    public static final String CANTOR_MULTICLOUDJ_BUFFER_DIRECTORY = "buffer.directory";
+    public static final String CANTOR_MULTICLOUDJ_SETS_TYPE = "sets.type";
 }

--- a/cantor-server/src/main/java/com/salesforce/cantor/server/utils/CantorFactory.java
+++ b/cantor-server/src/main/java/com/salesforce/cantor/server/utils/CantorFactory.java
@@ -23,16 +23,20 @@ import com.salesforce.cantor.misc.async.AsyncCantor;
 import com.salesforce.cantor.misc.loggable.LoggableCantor;
 import com.salesforce.cantor.misc.rw.ReadWriteCantor;
 import com.salesforce.cantor.misc.sharded.ShardedCantor;
+import com.salesforce.cantor.multicloudj.EventsOnMulticloudj;
+import com.salesforce.cantor.multicloudj.ObjectsOnMulticloudj;
 import com.salesforce.cantor.mysql.CantorOnMysql;
 import com.salesforce.cantor.mysql.MysqlDataSourceProperties;
 import com.salesforce.cantor.mysql.MysqlDataSourceProvider;
 import com.salesforce.cantor.s3.CantorOnS3;
 import com.salesforce.cantor.server.CantorEnvironment;
+import com.salesforce.multicloudj.blob.client.BucketClient;
 import com.typesafe.config.Config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -48,6 +52,14 @@ import static com.salesforce.cantor.server.Constants.CANTOR_MYSQL_HOSTNAME;
 import static com.salesforce.cantor.server.Constants.CANTOR_MYSQL_PASSWORD;
 import static com.salesforce.cantor.server.Constants.CANTOR_MYSQL_PORT;
 import static com.salesforce.cantor.server.Constants.CANTOR_MYSQL_USERNAME;
+import static com.salesforce.cantor.server.Constants.CANTOR_MULTICLOUDJ_BUCKET_NAME;
+import static com.salesforce.cantor.server.Constants.CANTOR_MULTICLOUDJ_BUCKET_REGION;
+import static com.salesforce.cantor.server.Constants.CANTOR_MULTICLOUDJ_BUFFER_DIRECTORY;
+import static com.salesforce.cantor.server.Constants.CANTOR_MULTICLOUDJ_ENDPOINT_OVERRIDE;
+import static com.salesforce.cantor.server.Constants.CANTOR_MULTICLOUDJ_PROVIDER;
+import static com.salesforce.cantor.server.Constants.CANTOR_MULTICLOUDJ_PROXY_HOST;
+import static com.salesforce.cantor.server.Constants.CANTOR_MULTICLOUDJ_PROXY_PORT;
+import static com.salesforce.cantor.server.Constants.CANTOR_MULTICLOUDJ_SETS_TYPE;
 import static com.salesforce.cantor.server.Constants.CANTOR_S3_BUCKET_NAME;
 import static com.salesforce.cantor.server.Constants.CANTOR_S3_BUCKET_REGION;
 import static com.salesforce.cantor.server.Constants.CANTOR_S3_ENDPOINT_OVERRIDE;
@@ -89,7 +101,90 @@ public class CantorFactory {
                 }
             });
         }
+        if (storageType.equalsIgnoreCase("multicloudj")) {
+            return createMulticloudjCantor();
+        }
         return getCantorByType(storageType);
+    }
+
+    private Cantor createMulticloudjCantor() throws IOException {
+        final Config config = this.cantorEnvironment.getConfig("multicloudj");
+
+        if (!config.hasPath(CANTOR_MULTICLOUDJ_SETS_TYPE)) {
+            throw new IllegalArgumentException("Missing configuration setting for 'multicloudj." + CANTOR_MULTICLOUDJ_SETS_TYPE + "'");
+        }
+
+        final String providerId = config.hasPath(CANTOR_MULTICLOUDJ_PROVIDER) ? config.getString(CANTOR_MULTICLOUDJ_PROVIDER) : "";
+        if (Strings.isNullOrEmpty(providerId)) {
+            throw new IllegalArgumentException("Provider invalid. Please set 'multicloudj." + CANTOR_MULTICLOUDJ_PROVIDER + "' (supported: aws, gcp, ali)");
+        }
+
+        final String bucketName = config.hasPath(CANTOR_MULTICLOUDJ_BUCKET_NAME) ? config.getString(CANTOR_MULTICLOUDJ_BUCKET_NAME) : "";
+        if (Strings.isNullOrEmpty(bucketName)) {
+            throw new IllegalArgumentException("Bucket name invalid. Please set 'multicloudj." + CANTOR_MULTICLOUDJ_BUCKET_NAME + "'");
+        }
+
+        logger.info("creating multicloudj cantor instance with provider '{}', bucket '{}', sets on {}...",
+                providerId, bucketName, config.getString(CANTOR_MULTICLOUDJ_SETS_TYPE));
+
+        // no support for multicloudj on sets therefore another cantor type must be used
+        final Sets sets = getCantorByType(config.getString(CANTOR_MULTICLOUDJ_SETS_TYPE)).sets();
+
+        final BucketClient bucketClient = createBucketClient(config, providerId, bucketName);
+        final ObjectsOnMulticloudj objects = new ObjectsOnMulticloudj(bucketClient);
+        final EventsOnMulticloudj events = buildEventsOnMulticloudj(config, bucketClient);
+
+        // CantorOnMulticloudj is final, so wrap with a Cantor delegate that supplies the Sets backend
+        return new LoggableCantor(new Cantor() {
+            @Override
+            public com.salesforce.cantor.Objects objects() {
+                return objects;
+            }
+
+            @Override
+            public com.salesforce.cantor.Events events() {
+                return events;
+            }
+
+            @Override
+            public Sets sets() {
+                return sets;
+            }
+        });
+    }
+
+    private static BucketClient createBucketClient(final Config config, final String providerId, final String bucketName) {
+        final String region = config.hasPath(CANTOR_MULTICLOUDJ_BUCKET_REGION) ? config.getString(CANTOR_MULTICLOUDJ_BUCKET_REGION) : "";
+
+        final BucketClient.BlobBuilder builder = BucketClient.builder(providerId)
+                .withBucket(bucketName);
+
+        if (!Strings.isNullOrEmpty(region)) {
+            builder.withRegion(region);
+        }
+
+        final String endpointOverride = config.hasPath(CANTOR_MULTICLOUDJ_ENDPOINT_OVERRIDE)
+                ? config.getString(CANTOR_MULTICLOUDJ_ENDPOINT_OVERRIDE) : "";
+        if (!Strings.isNullOrEmpty(endpointOverride)) {
+            builder.withEndpoint(URI.create(endpointOverride));
+        }
+
+        final String proxyHost = config.hasPath(CANTOR_MULTICLOUDJ_PROXY_HOST) ? config.getString(CANTOR_MULTICLOUDJ_PROXY_HOST) : "";
+        final int proxyPort = config.hasPath(CANTOR_MULTICLOUDJ_PROXY_PORT) ? config.getInt(CANTOR_MULTICLOUDJ_PROXY_PORT) : -1;
+        if (!Strings.isNullOrEmpty(proxyHost) && proxyPort > 0) {
+            builder.withProxyEndpoint(URI.create(String.format("http://%s:%d", proxyHost, proxyPort)));
+        }
+
+        return builder.build();
+    }
+
+    private static EventsOnMulticloudj buildEventsOnMulticloudj(final Config config, final BucketClient bucketClient) throws IOException {
+        final String bufferDirectory = config.hasPath(CANTOR_MULTICLOUDJ_BUFFER_DIRECTORY)
+                ? config.getString(CANTOR_MULTICLOUDJ_BUFFER_DIRECTORY) : "";
+        if (!Strings.isNullOrEmpty(bufferDirectory)) {
+            return new EventsOnMulticloudj(bucketClient, bufferDirectory);
+        }
+        return new EventsOnMulticloudj(bucketClient);
     }
 
     private Cantor getCantorByType(final String storageType) throws IOException {

--- a/cantor-server/src/main/resources/cantor-server.conf
+++ b/cantor-server/src/main/resources/cantor-server.conf
@@ -38,4 +38,12 @@ cantor {
     region=us-west-2
     sets.type=h2
   }
+
+  multicloudj = {
+    # supported providers: aws, gcp, ali
+    provider=aws
+    bucket=bucket-placeholder
+    region=us-west-2
+    sets.type=h2
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,7 @@
         <module>cantor-h2</module>
         <module>cantor-mysql</module>
         <module>cantor-s3</module>
+        <module>cantor-multicloudj</module>
         <module>cantor-misc</module>
         <module>cantor-metrics</module>
         <module>cantor-server</module>


### PR DESCRIPTION
## Overview

Introduces `cantor-multicloudj`, a new Maven module that implements Cantor's `Objects` and `Events` interfaces on top of `com.salesforce.multicloudj` `BucketClient`. One codebase targets AWS S3, Alibaba Cloud OSS, and GCP Cloud Storage through a single cloud-agnostic abstraction, so deployments can switch backends by swapping the underlying `BucketClient` without touching Cantor application code.

This change is purely additive. The only edit outside the new module is registering it in the parent `pom.xml`; no existing module's behavior changes.

## What's added

- **`CantorOnMulticloudj`** — top-level facade exposing `objects()` and `events()`, with `BucketClient` and convenience constructors.
- **`ObjectsOnMulticloudj`** — full Objects contract: `store`, `get`, `delete`, `keys`, `size`, and streaming variants, backed by object-storage primitives.
- **`EventsOnMulticloudj`** — Events contract via a buffer-and-flush model with client-side filtering on metadata/dimensions; flushes buffered events before namespace expiry so in-flight writes are not lost.
- **`MulticloudjUtils`** — shared helpers for listing, batched deletes, and namespace key trimming.
- **`AbstractBaseMulticloudjNamespaceable`** — hoisted base class for shared namespace `create` / `drop` / `exists` logic and constants, de-duplicated across Objects and Events.
- **Module `README.md`** with usage, supported backends, and an explicit Known Limitations / Trade-offs section.

## Security hardening

- **Bounded blob downloads** — max-size guard on object reads to prevent OOM on adversarial or accidentally huge objects.
- **Restrictive event-buffer directory permissions** — buffer dir is created with owner-only permissions (`0700`).
- **Path traversal validation** — buffer directory path is validated and canonicalized before use to block `..`-style escapes.

## Tests

- 118 tests covering Objects, Events, namespace lifecycle, buffering/flush semantics, and edge cases.
- **No cloud credentials required** — tests run against the `blob-inmemory` multicloudj provider, so CI and local dev work offline.

## Known limitations / trade-offs

- **No server-side filtering / S3 Select equivalent.** `multicloudj`'s `BucketClient` does not expose an S3 Select-style API across backends, so Events filtering is performed client-side after fetching the candidate blobs. This is the main perf trade-off versus a native S3 implementation and is called out in the module README.
- **Eventually-consistent listing semantics** are inherited from the underlying object store; callers needing strong read-your-writes on `keys()` should account for backend behavior.
- **Events use a buffer-and-flush model**, not per-event writes, so very recent events may not be visible until the buffer flushes (flush is forced before namespace expiry to prevent data loss).

## Test plan

- [ ] `mvn -pl cantor-multicloudj -am clean install` builds cleanly from a fresh checkout
- [ ] `mvn -pl cantor-multicloudj test` passes all 118 tests with no cloud credentials configured
- [ ] Verify `cantor-multicloudj` appears as a module in the root `pom.xml` and no other module's build output changes
- [ ] Spot-check `ObjectsOnMulticloudj` against the `Objects` interface contract (store/get/delete/keys/stream round-trip)
- [ ] Spot-check `EventsOnMulticloudj` buffer-and-flush behavior and client-side filtering on metadata + dimensions
- [ ] Confirm event buffer directory is created with `0700` perms and rejects path-traversal inputs
- [ ] Confirm blob download size guard rejects oversize objects with a clear error rather than OOM



## Server Integration

`cantor-server` is now wired to construct a `cantor-multicloudj` Cantor at runtime based on config.

- **`CantorFactory`** — new `multicloudj` branch alongside the existing `s3` / `mysql` / `h2` types. Reads `provider`, `bucket`, `region` from config; builds a `BucketClient` via the multicloudj builder API; supports optional `endpoint.override` (`.withEndpoint(URI)`), optional proxy (`.withProxyEndpoint(URI)`), and optional `buffer.directory` for `EventsOnMulticloudj`. Because `Sets` is not implemented by this backend (matches `cantor-s3`), the factory sources `Sets` from another cantor type configured under `multicloudj.sets.type`.
- **`Constants.java`** — 8 new keys under the `multicloudj` config namespace: `provider`, `bucket`, `region`, `proxy.host`, `proxy.port`, `endpoint.override`, `buffer.directory`, `sets.type`.
- **`cantor-server.conf`** — default template block:
  ```
  multicloudj = {
      # supported providers: aws, gcp, ali
      provider=aws
      bucket=bucket-placeholder
      region=us-west-2
      sets.type=h2
  }
  ```
- **`cantor-server/pom.xml`** — adds `cantor-multicloudj` compile dep, and declares `blob-aws` / `blob-ali` / `blob-gcp` (multicloudj 0.4.0) as `runtime` + `optional` deps so deployers can choose which cloud provider(s) to ship.

### Usage

Set `cantor.storage.type = multicloudj` in `cantor-server.conf`, configure the `multicloudj { ... }` block, and ensure the matching `blob-<provider>` runtime dependency is on the classpath (they are declared `optional` in the server pom so consumers pick per-deployment).

### Server integration test plan

- [ ] `mvn -pl cantor-server -am compile` succeeds
- [ ] Starting `cantor-server` with `storage.type = multicloudj` and a valid `multicloudj` config block produces a working Cantor that routes Objects/Events to the configured cloud provider and Sets to the type named in `multicloudj.sets.type`
- [ ] Config validation rejects empty/missing `provider` or `bucket` with clear error messages
- [ ] Optional `endpoint.override`, proxy, and `buffer.directory` are honored when present and skipped when absent
